### PR TITLE
feat: Ajout d'un bouton Se connecter

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(sudo lsof:*)"
+    ]
+  }
+}

--- a/apps/accounts/forms.py
+++ b/apps/accounts/forms.py
@@ -1,8 +1,8 @@
 import random
 
 from django import forms
-from django.contrib.auth import get_user_model
-from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth import authenticate, get_user_model
+from django.contrib.auth.forms import AuthenticationForm, UserCreationForm
 
 User = get_user_model()
 
@@ -31,3 +31,33 @@ class SignUpForm(UserCreationForm):
         if commit:
             user.save()
         return user
+
+
+class LoginForm(AuthenticationForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["username"].label = "Adresse email"
+
+    def clean(self):
+        email = self.cleaned_data.get("username")
+        password = self.cleaned_data.get("password")
+
+        if email and password:
+            try:
+                user = User.objects.get(email__iexact=email)
+            except User.DoesNotExist:
+                raise forms.ValidationError(
+                    "Adresse email ou mot de passe incorrect."
+                )
+
+            self.user_cache = authenticate(
+                self.request, username=user.username, password=password
+            )
+            if self.user_cache is None:
+                raise forms.ValidationError(
+                    "Adresse email ou mot de passe incorrect."
+                )
+            else:
+                self.confirm_login_allowed(self.user_cache)
+
+        return self.cleaned_data

--- a/apps/accounts/tests/test_forms.py
+++ b/apps/accounts/tests/test_forms.py
@@ -1,7 +1,8 @@
 import pytest
 from django.contrib.auth import get_user_model
+from django.test import RequestFactory
 
-from apps.accounts.forms import SignUpForm
+from apps.accounts.forms import LoginForm, SignUpForm
 
 from .factories import UserFactory
 
@@ -88,3 +89,46 @@ class TestSignUpForm:
         assert form.is_valid()
         user = form.save()
         assert user.username.startswith("jean.dupont")
+
+
+@pytest.mark.django_db
+class TestLoginForm:
+    def setup_method(self):
+        self.factory = RequestFactory()
+        self.password = "Str0ngP@ss!"
+        self.user = UserFactory(email="test@example.com", password=self.password)
+
+    def _get_form(self, data):
+        request = self.factory.post("/comptes/connexion/")
+        return LoginForm(request=request, data=data)
+
+    def test_login_form_valid_credentials(self):
+        form = self._get_form(
+            {"username": "test@example.com", "password": self.password}
+        )
+        assert form.is_valid()
+
+    def test_login_form_invalid_email(self):
+        form = self._get_form(
+            {"username": "nonexistent@example.com", "password": self.password}
+        )
+        assert not form.is_valid()
+
+    def test_login_form_invalid_password(self):
+        form = self._get_form(
+            {"username": "test@example.com", "password": "wrongpassword"}
+        )
+        assert not form.is_valid()
+
+    def test_login_form_email_label(self):
+        request = self.factory.get("/comptes/connexion/")
+        form = LoginForm(request=request)
+        assert form.fields["username"].label == "Adresse email"
+
+    def test_login_form_error_message_in_french(self):
+        form = self._get_form(
+            {"username": "test@example.com", "password": "wrongpassword"}
+        )
+        form.is_valid()
+        errors = form.non_field_errors()
+        assert any("incorrect" in str(e).lower() for e in errors)

--- a/apps/accounts/tests/test_views.py
+++ b/apps/accounts/tests/test_views.py
@@ -2,9 +2,13 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.test import Client
 
+from .factories import UserFactory
+
 User = get_user_model()
 
 SIGNUP_URL = "/comptes/inscription/"
+LOGIN_URL = "/comptes/connexion/"
+LOGOUT_URL = "/comptes/deconnexion/"
 
 
 @pytest.mark.django_db
@@ -97,3 +101,126 @@ class TestSignUpView:
         response = self.client.get(SIGNUP_URL)
         content = response.content.decode()
         assert "Créez votre compte pour accéder au blog." in content
+
+    def test_signup_page_contains_login_link(self):
+        response = self.client.get(SIGNUP_URL)
+        content = response.content.decode()
+        assert "/comptes/connexion/" in content
+
+
+@pytest.mark.django_db
+class TestLoginView:
+    def setup_method(self):
+        self.client = Client()
+        self.password = "Str0ngP@ss!"
+        self.user = UserFactory(email="login@example.com", password=self.password)
+
+    def test_login_page_returns_200(self):
+        response = self.client.get(LOGIN_URL)
+        assert response.status_code == 200
+
+    def test_login_page_uses_correct_template(self):
+        response = self.client.get(LOGIN_URL)
+        assert "accounts/login.html" in [t.name for t in response.templates]
+
+    def test_login_page_contains_form(self):
+        response = self.client.get(LOGIN_URL)
+        content = response.content.decode()
+        assert 'type="email"' in content
+        assert 'type="password"' in content
+
+    def test_login_page_contains_csrf(self):
+        response = self.client.get(LOGIN_URL)
+        content = response.content.decode()
+        assert "csrfmiddlewaretoken" in content
+
+    def test_login_success_redirects(self):
+        response = self.client.post(
+            LOGIN_URL,
+            {"username": "login@example.com", "password": self.password},
+        )
+        assert response.status_code == 302
+
+    def test_login_success_authenticates_user(self):
+        response = self.client.post(
+            LOGIN_URL,
+            {"username": "login@example.com", "password": self.password},
+            follow=True,
+        )
+        assert response.wsgi_request.user.is_authenticated
+        assert response.wsgi_request.user == self.user
+
+    def test_login_invalid_credentials_returns_200(self):
+        response = self.client.post(
+            LOGIN_URL,
+            {"username": "login@example.com", "password": "wrongpass"},
+        )
+        assert response.status_code == 200
+
+    def test_login_invalid_credentials_shows_error(self):
+        response = self.client.post(
+            LOGIN_URL,
+            {"username": "login@example.com", "password": "wrongpass"},
+        )
+        content = response.content.decode()
+        assert "incorrect" in content.lower() or "erreur" in content.lower()
+
+    def test_login_seo_title(self):
+        response = self.client.get(LOGIN_URL)
+        content = response.content.decode()
+        assert "<title>Se connecter</title>" in content
+
+    def test_login_seo_meta_description(self):
+        response = self.client.get(LOGIN_URL)
+        content = response.content.decode()
+        assert "Connectez-vous à votre compte pour accéder au blog." in content
+
+    def test_login_contains_signup_link(self):
+        response = self.client.get(LOGIN_URL)
+        content = response.content.decode()
+        assert "/comptes/inscription/" in content
+
+    def test_login_redirects_authenticated_user(self):
+        self.client.login(username=self.user.username, password=self.password)
+        response = self.client.get(LOGIN_URL)
+        assert response.status_code == 302
+
+    def test_login_with_email(self):
+        response = self.client.post(
+            LOGIN_URL,
+            {"username": "login@example.com", "password": self.password},
+            follow=True,
+        )
+        assert response.wsgi_request.user.is_authenticated
+        assert response.wsgi_request.user.email == "login@example.com"
+
+
+@pytest.mark.django_db
+class TestLogoutView:
+    def setup_method(self):
+        self.client = Client()
+        self.password = "Str0ngP@ss!"
+        self.user = UserFactory(email="logout@example.com", password=self.password)
+
+    def test_logout_redirects_to_home(self):
+        self.client.login(username=self.user.username, password=self.password)
+        response = self.client.post(LOGOUT_URL)
+        assert response.status_code == 302
+        assert response.url == "/"
+
+    def test_logout_actually_logs_out(self):
+        self.client.login(username=self.user.username, password=self.password)
+        self.client.post(LOGOUT_URL)
+        response = self.client.get("/")
+        assert not response.wsgi_request.user.is_authenticated
+
+
+@pytest.mark.django_db
+class TestComingSoonView:
+    def setup_method(self):
+        self.client = Client()
+
+    def test_coming_soon_contains_login_link(self):
+        response = self.client.get("/")
+        content = response.content.decode()
+        assert "/comptes/connexion/" in content

--- a/apps/accounts/urls.py
+++ b/apps/accounts/urls.py
@@ -1,9 +1,11 @@
 from django.urls import path
 
-from .views import SignUpView
+from .views import LoginView, LogoutView, SignUpView
 
 app_name = "accounts"
 
 urlpatterns = [
     path("inscription/", SignUpView.as_view(), name="signup"),
+    path("connexion/", LoginView.as_view(), name="login"),
+    path("deconnexion/", LogoutView.as_view(), name="logout"),
 ]

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -1,8 +1,10 @@
 from django.contrib.auth import login
+from django.contrib.auth import views as auth_views
+from django.shortcuts import redirect
 from django.urls import reverse_lazy
 from django.views.generic import CreateView
 
-from .forms import SignUpForm
+from .forms import LoginForm, SignUpForm
 
 
 class SignUpView(CreateView):
@@ -14,3 +16,17 @@ class SignUpView(CreateView):
         response = super().form_valid(form)
         login(self.request, self.object)
         return response
+
+
+class LoginView(auth_views.LoginView):
+    template_name = "accounts/login.html"
+    form_class = LoginForm
+
+    def dispatch(self, request, *args, **kwargs):
+        if request.user.is_authenticated:
+            return redirect(self.get_success_url())
+        return super().dispatch(request, *args, **kwargs)
+
+
+class LogoutView(auth_views.LogoutView):
+    pass

--- a/templates/accounts/login.html
+++ b/templates/accounts/login.html
@@ -1,0 +1,75 @@
+{% extends "base.html" %}
+
+{% block title %}Se connecter{% endblock %}
+
+{% block meta_description %}Connectez-vous à votre compte pour accéder au blog.{% endblock %}
+
+{% block content %}
+<div class="min-h-screen flex items-center justify-center">
+    <div class="bg-white shadow-lg rounded-lg p-8 max-w-md w-full">
+        <h1 class="text-3xl font-bold text-gray-800 text-center mb-6">Se connecter</h1>
+
+        {% if form.non_field_errors %}
+        <div class="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg">
+            {% for error in form.non_field_errors %}
+            <p class="text-red-600 text-sm">{{ error }}</p>
+            {% endfor %}
+        </div>
+        {% endif %}
+
+        <form method="post" novalidate>
+            {% csrf_token %}
+
+            <div class="mb-4">
+                <label for="{{ form.username.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-1">
+                    Adresse email
+                </label>
+                <input type="email"
+                       name="{{ form.username.html_name }}"
+                       id="{{ form.username.id_for_label }}"
+                       value="{{ form.username.value|default:'' }}"
+                       required
+                       class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition{% if form.username.errors %} border-red-500{% endif %}">
+                {% if form.username.errors %}
+                <ul class="errorlist mt-1">
+                    {% for error in form.username.errors %}
+                    <li class="text-red-600 text-sm">{{ error }}</li>
+                    {% endfor %}
+                </ul>
+                {% endif %}
+            </div>
+
+            <div class="mb-6">
+                <label for="{{ form.password.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-1">
+                    Mot de passe
+                </label>
+                <input type="password"
+                       name="{{ form.password.html_name }}"
+                       id="{{ form.password.id_for_label }}"
+                       required
+                       class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none transition{% if form.password.errors %} border-red-500{% endif %}">
+                {% if form.password.errors %}
+                <ul class="errorlist mt-1">
+                    {% for error in form.password.errors %}
+                    <li class="text-red-600 text-sm">{{ error }}</li>
+                    {% endfor %}
+                </ul>
+                {% endif %}
+            </div>
+
+            <button type="submit"
+                    class="w-full bg-blue-600 text-white py-3 px-6 rounded-lg font-semibold hover:bg-blue-700 transition">
+                Se connecter
+            </button>
+        </form>
+
+        <div class="mt-6 text-center space-y-2">
+            <p class="text-sm text-gray-600">
+                Pas encore de compte ?
+                <a href="{% url 'accounts:signup' %}" class="text-blue-600 hover:text-blue-800 font-medium">Créer un compte</a>
+            </p>
+            <a href="{% url 'coming_soon' %}" class="text-blue-600 hover:text-blue-800 text-sm">Retour</a>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/accounts/signup.html
+++ b/templates/accounts/signup.html
@@ -82,7 +82,11 @@
             </button>
         </form>
 
-        <div class="mt-6 text-center">
+        <div class="mt-6 text-center space-y-2">
+            <p class="text-sm text-gray-600">
+                Déjà un compte ?
+                <a href="{% url 'accounts:login' %}" class="text-blue-600 hover:text-blue-800 font-medium">Se connecter</a>
+            </p>
             <a href="{% url 'coming_soon' %}" class="text-blue-600 hover:text-blue-800 text-sm">Retour</a>
         </div>
     </div>

--- a/templates/core/coming_soon.html
+++ b/templates/core/coming_soon.html
@@ -9,10 +9,16 @@
     <div class="text-center">
         <h1 class="text-5xl font-bold text-gray-800">Coming Soon</h1>
         <p class="text-xl text-gray-500 mt-4">Notre blog arrive bientôt. Restez connectés !</p>
-        <a href="{% url 'accounts:signup' %}"
-           class="inline-block mt-6 bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700 transition font-semibold">
-            Créer un compte
-        </a>
+        <div class="mt-6 flex flex-col sm:flex-row items-center justify-center gap-4">
+            <a href="{% url 'accounts:signup' %}"
+               class="inline-block bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700 transition font-semibold">
+                Créer un compte
+            </a>
+            <a href="{% url 'accounts:login' %}"
+               class="inline-block border border-blue-600 text-blue-600 px-6 py-3 rounded-lg hover:bg-blue-50 transition font-semibold">
+                Se connecter
+            </a>
+        </div>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Description

Closes #6

---

## Documentation

## Fonctionnalité : Ajout d'un bouton "Se connecter" (closes #6)

### 1. Ce qui a été implémenté

**Fichiers créés :**
- `templates/accounts/login.html` — Page de connexion avec formulaire email/mot de passe, style Tailwind cohérent avec la page d'inscription

**Fichiers modifiés :**
- `apps/accounts/urls.py` — Ajout des routes `connexion/` et `deconnexion/` (noms : `accounts:login`, `accounts:logout`)
- `apps/accounts/views.py` — Ajout de `LoginView` (avec redirection des utilisateurs déjà authentifiés) et `LogoutView`
- `apps/accounts/forms.py` — Ajout de `LoginForm` avec authentification par email au lieu du username Django par défaut
- `templates/core/coming_soon.html` — Ajout d'un bouton secondaire "Se connecter" à côté de "Créer un compte"
- `templates/accounts/signup.html` — Ajout du lien "Déjà un compte ? Se connecter"
- `apps/accounts/tests/test_views.py` — 22 tests : `TestLoginView` (13 tests), `TestLogoutView` (2 tests), `TestComingSoonView` (1 test), + tests signup existants enrichis
- `apps/accounts/tests/test_forms.py` — 5 tests pour `TestLoginForm` (credentials valides/invalides, label, messages FR)

### 2. Choix techniques

**Authentification par email via `LoginForm.clean()`** — Plutôt que de configurer un backend d'authentification custom (`AUTHENTICATION_BACKENDS`), le `LoginForm` surcharge `clean()` pour résoudre l'email en username avant d'appeler `authenticate()`. Ce choix est plus léger et localisé : la logique de conversion email → username reste dans le formulaire sans impacter le reste du système d'auth Django. La recherche email est case-insensitive (`email__iexact`).

```python
# Le formulaire intercepte l'email, trouve le User, puis authentifie avec son username
user = User.objects.get(email__iexact=email)
self.user_cache = authenticate(self.request, username=user.username, password=password)
```

**Redirection via `dispatch()` plutôt que `redirect_authenticated_users`** — La `LoginView` surcharge `dispatch()` pour rediriger les utilisateurs déjà connectés. C'est fonctionnellement équivalent à `redirect_authenticated_users = True` mais plus explicite et plus facile à tester.

**Messages d'erreur unifiés en français** — Le même message `"Adresse email ou mot de passe incorrect."` est affiché que l'email soit inexistant ou que le mot de passe soit faux. C'est une bonne pratique de sécurité : ne pas révéler si un email est enregistré ou non.

**Bouton secondaire sur la page Coming Soon** — Le bouton "Se connecter" utilise un style outline (`border border-blue-600 text-blue-600`) pour hiérarchiser visuellement par rapport au CTA principal "Créer un compte".

### 3. Comment utiliser cette évolution

**URLs disponibles :**

| URL | Méthode | Description |
|-----|---------|-------------|
| `/comptes/connexion/` | GET | Affiche le formulaire de connexion |
| `/comptes/connexion/` | POST | Authentifie l'utilisateur (champs : `username` = email, `password`) |
| `/comptes/deconnexion/` | POST | Déconnecte l'utilisateur, redirige vers `/` |

**Flux utilisateur :**
1. L'utilisateur arrive sur la page Coming Soon (`/`)
2. Il clique sur "Se connecter" → `/comptes/connexion/`
3. Il saisit son **adresse email** et son mot de passe
4. Après connexion réussie → redirection vers `/` (`LOGIN_REDIRECT_URL`)

**Lancer les tests :**
```bash
# Tous les tests accounts
docker compose exec django pytest apps/accounts/ -v

# Uniquement les tests de connexion
docker compose exec django pytest apps/accounts/tests/test_views.py::TestLoginView -v
docker compose exec django pytest apps/accounts/tests/test_forms.py::TestLoginForm -v
```

**Pas de migration nécessaire** — Cette PR n'ajoute aucun modèle, elle s'appuie sur `django.contrib.auth` existant.

### 4. Points d'attention

- **Champ `username` du formulaire HTML** — Bien que le label affiche "Adresse email" et que l'`<input>` soit de type `email`, le `name` du champ reste `username` (imposé par `AuthenticationForm` de Django). Les tests POST envoient donc `{"username": "email@example.com", "password": "..."}`.

- **Génération du username** — Le `SignUpForm` génère un username à partir de la partie locale de l'email avec un suffixe aléatoire en cas de collision (`local_part_{1000-9999}`). Ce mécanisme utilise `random.randint` : en cas de très nombreuses collisions sur un même préfixe (> 9000 utilisateurs avec le même local part), la boucle pourrait être lente. Ce n'est pas un problème réaliste mais c'est à noter.

- **Pas de fonctionnalité "mot de passe oublié"** — Le flux de connexion est complet (login + logout) mais ne propose pas de réinitialisation de mot de passe. C'est un ticket séparé à prévoir.

- **`LogoutView` en POST uniquement** — Conformément aux bonnes pratiques Django (protection CSRF), la déconnexion nécessite une requête POST. Un GET sur `/comptes/deconnexion/` retournera une erreur 405.