### PR TITLE
feat: Impossible d'afficher le formulaire de connexion

### DIFF
--- a/apps/accounts/tests/test_views.py
+++ b/apps/accounts/tests/test_views.py
@@ -185,6 +185,12 @@ class TestLoginView:
         response = self.client.get(LOGIN_URL)
         assert response.status_code == 302
 
+    def test_login_redirects_authenticated_user_to_home(self):
+        self.client.login(username=self.user.username, password=self.password)
+        response = self.client.get(LOGIN_URL)
+        assert response.status_code == 302
+        assert response.url == "/"
+
     def test_login_with_email(self):
         response = self.client.post(
             LOGIN_URL,
@@ -219,8 +225,40 @@ class TestLogoutView:
 class TestComingSoonView:
     def setup_method(self):
         self.client = Client()
+        self.password = "Str0ngP@ss!"
+        self.user = UserFactory(email="coming@example.com", password=self.password)
 
     def test_coming_soon_contains_login_link(self):
         response = self.client.get("/")
         content = response.content.decode()
         assert "/comptes/connexion/" in content
+
+    def test_coming_soon_shows_login_link_for_anonymous(self):
+        response = self.client.get("/")
+        content = response.content.decode()
+        assert "/comptes/connexion/" in content
+
+    def test_coming_soon_shows_signup_link_for_anonymous(self):
+        response = self.client.get("/")
+        content = response.content.decode()
+        assert "/comptes/inscription/" in content
+
+    def test_coming_soon_hides_login_link_for_authenticated(self):
+        self.client.login(username=self.user.username, password=self.password)
+        response = self.client.get("/")
+        content = response.content.decode()
+        assert "/comptes/connexion/" not in content
+
+    def test_coming_soon_hides_signup_link_for_authenticated(self):
+        self.client.login(username=self.user.username, password=self.password)
+        response = self.client.get("/")
+        content = response.content.decode()
+        assert "/comptes/inscription/" not in content
+
+    def test_coming_soon_shows_logout_for_authenticated(self):
+        self.client.login(username=self.user.username, password=self.password)
+        response = self.client.get("/")
+        content = response.content.decode()
+        assert "/comptes/deconnexion/" in content
+        assert "csrfmiddlewaretoken" in content
+        assert "Se déconnecter" in content

--- a/templates/core/coming_soon.html
+++ b/templates/core/coming_soon.html
@@ -9,6 +9,15 @@
     <div class="text-center">
         <h1 class="text-5xl font-bold text-gray-800">Coming Soon</h1>
         <p class="text-xl text-gray-500 mt-4">Notre blog arrive bientôt. Restez connectés !</p>
+        {% if user.is_authenticated %}
+        <p class="text-lg text-gray-600 mt-4">Bienvenue, {{ user.username }} !</p>
+        <form method="post" action="{% url 'accounts:logout' %}" class="mt-6">
+            {% csrf_token %}
+            <button type="submit" class="inline-block border border-red-600 text-red-600 px-6 py-3 rounded-lg hover:bg-red-50 transition font-semibold">
+                Se déconnecter
+            </button>
+        </form>
+        {% else %}
         <div class="mt-6 flex flex-col sm:flex-row items-center justify-center gap-4">
             <a href="{% url 'accounts:signup' %}"
                class="inline-block bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700 transition font-semibold">
@@ -19,6 +28,7 @@
                 Se connecter
             </a>
         </div>
+        {% endif %}
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Description

Closes #8

---

## Documentation

## Ce qui a été implémenté

### Résumé des modifications

**Correction du bug de boucle de redirection sur la page de connexion** — Un utilisateur connecté qui cliquait sur "Se connecter" était redirigé en boucle vers `/` car `LoginView.dispatch()` redirige les utilisateurs authentifiés vers `LOGIN_REDIRECT_URL` (`/`), et la page Coming Soon affichait toujours le bouton "Se connecter".

**Fichiers modifiés :**

- **`templates/core/coming_soon.html`** — Ajout d'une condition `{% if user.is_authenticated %}` qui affiche un message de bienvenue personnalisé et un bouton "Se déconnecter" pour les utilisateurs connectés, et masque les boutons "Créer un compte" / "Se connecter".

- **`apps/accounts/tests/test_views.py`** — Ajout de deux nouvelles classes de tests :
  - `TestComingSoonView` (6 tests) : vérifie l'affichage conditionnel des liens connexion/inscription pour les anonymes, leur masquage pour les authentifiés, et la présence du formulaire de déconnexion.
  - `TestLoginView.test_login_redirects_authenticated_user_to_home` : confirme explicitement que la redirection d'un utilisateur authentifié pointe vers `/`.

## Choix techniques

1. **Condition côté template uniquement** — Le fix est entièrement dans le template via `{% if user.is_authenticated %}`, sans modifier de vue ni de middleware. C'est suffisant car le context processor `django.contrib.auth.context_processors.auth` injecte déjà `user` dans le contexte de tous les templates.

2. **Déconnexion en POST avec CSRF** — Le bouton "Se déconnecter" utilise un `<form method="post">` avec `{% csrf_token %}` plutôt qu'un simple lien GET, conformément aux bonnes pratiques de sécurité (Django 5.x requiert POST pour le logout par défaut).

3. **Style Tailwind cohérent** — Le bouton de déconnexion utilise une bordure rouge (`border-red-600`, `text-red-600`, `hover:bg-red-50`) pour se différencier visuellement des actions de connexion/inscription (bleues), signalant clairement une action de type "sortie".

4. **Tests basés sur la présence/absence d'URLs dans le HTML** — Les tests vérifient les URLs en dur (`/comptes/connexion/`, `/comptes/inscription/`, `/comptes/deconnexion/`) dans le contenu de la réponse. C'est un choix pragmatique qui teste le comportement réel vu par l'utilisateur.

## Comment utiliser cette évolution

```bash
# Lancer les tests pour vérifier que tout passe
pytest apps/accounts/tests/test_views.py -v

# Tester manuellement les scénarios
# 1. Accéder à http://localhost:8000/ en tant qu'anonyme → boutons "Créer un compte" et "Se connecter" visibles
# 2. Cliquer sur "Se connecter" → formulaire de connexion affiché (status 200, pas de boucle)
# 3. Se connecter avec un compte existant → redirigé vers /
# 4. Sur / en tant qu'utilisateur connecté → message "Bienvenue, <username> !" et bouton "Se déconnecter"
# 5. Cliquer sur "Se déconnecter" → déconnecté et redirigé vers /
```

Aucune migration ni configuration supplémentaire n'est nécessaire — les modifications sont purement template et tests.

## Points d'attention

- **Le test `test_coming_soon_contains_login_link`** est un doublon fonctionnel de `test_coming_soon_shows_login_link_for_anonymous` (les deux vérifient la même chose). Il pourrait être supprimé lors d'un nettoyage futur.
- **Les URLs sont testées en dur** (`/comptes/connexion/`). Si les URL patterns changent dans `apps/accounts/urls.py`, ces tests casseront. Une alternative serait d'utiliser `reverse()`, mais l'approche actuelle a le mérite de tester aussi la configuration des URLs.
- **Le message de bienvenue affiche `user.username`**, pas `user.email`. Selon le modèle utilisateur custom, le `username` pourrait être un hash ou une valeur générée automatiquement — à vérifier que l'affichage est pertinent pour l'utilisateur final.