### PR TITLE
feat: close #23 - Ajout d'une page Contact

### DIFF
--- a/apps/core/tests/test_views.py
+++ b/apps/core/tests/test_views.py
@@ -34,3 +34,50 @@ class TestAboutView:
     def test_about_url_is_a_propos(self, client: Client):
         url = reverse("about")
         assert url == "/a-propos/"
+
+
+@pytest.mark.django_db
+class TestContactView:
+    def test_contact_page_returns_200(self, client: Client):
+        response = client.get(reverse("contact"))
+        assert response.status_code == 200
+
+    def test_contact_page_uses_correct_template(self, client: Client):
+        response = client.get(reverse("contact"))
+        assert "core/contact.html" in [t.name for t in response.templates]
+
+    def test_contact_page_contains_nickorp(self, client: Client):
+        response = client.get(reverse("contact"))
+        content = response.content.decode()
+        assert "NICKORP" in content
+
+    def test_contact_page_has_title(self, client: Client):
+        response = client.get(reverse("contact"))
+        content = response.content.decode()
+        assert "<title>" in content
+        assert "Contact" in content
+
+    def test_contact_page_has_meta_description(self, client: Client):
+        response = client.get(reverse("contact"))
+        content = response.content.decode()
+        assert "Contactez NICKORP" in content
+
+    def test_contact_url_is_contact(self, client: Client):
+        url = reverse("contact")
+        assert url == "/contact/"
+
+    def test_contact_page_contains_github_link(self, client: Client):
+        response = client.get(reverse("contact"))
+        content = response.content.decode()
+        assert "https://github.com/nicolasdeclerck/" in content
+
+    def test_contact_page_contains_linkedin_link(self, client: Client):
+        response = client.get(reverse("contact"))
+        content = response.content.decode()
+        assert "https://www.linkedin.com/in/nicolas-declerck/" in content
+
+    def test_contact_link_in_navigation(self, client: Client):
+        response = client.get(reverse("home"))
+        content = response.content.decode()
+        assert "Contact" in content
+        assert reverse("contact") in content

--- a/apps/core/urls.py
+++ b/apps/core/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
 
-from .views import AboutView
+from .views import AboutView, ContactView
 
 urlpatterns = [
     path("a-propos/", AboutView.as_view(), name="about"),
+    path("contact/", ContactView.as_view(), name="contact"),
 ]

--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -15,3 +15,7 @@ class ComingSoonView(TemplateView):
 
 class AboutView(TemplateView):
     template_name = "core/about.html"
+
+
+class ContactView(TemplateView):
+    template_name = "core/contact.html"

--- a/templates/base.html
+++ b/templates/base.html
@@ -15,6 +15,7 @@
                 <a href="{% url 'home' %}" class="text-base font-semibold text-gray-900 hover:text-black">NICKORP</a>
                 <a href="{% url 'post_list' %}" class="nav-link">Articles</a>
                 <a href="{% url 'about' %}" class="nav-link">À propos</a>
+                <a href="{% url 'contact' %}" class="nav-link">Contact</a>
             </nav>
             <div class="flex items-center gap-3">
                 {% if user.is_authenticated %}

--- a/templates/core/contact.html
+++ b/templates/core/contact.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+
+{% block title %}Contact — NICKORP{% endblock %}
+
+{% block meta_description %}Contactez NICKORP — retrouvez-nous sur GitHub et LinkedIn.{% endblock %}
+
+{% block content %}
+<div class="max-w-3xl mx-auto px-4 py-12">
+    <h1 class="text-4xl font-bold text-gray-900 mb-8">Contact</h1>
+
+    <section class="mb-8">
+        <p class="text-gray-600 leading-relaxed mb-6">
+            Retrouvez-nous sur les plateformes suivantes :
+        </p>
+        <ul class="space-y-4">
+            <li>
+                <a href="https://github.com/nicolasdeclerck/" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:text-blue-800 font-medium">
+                    GitHub — nicolasdeclerck
+                </a>
+            </li>
+            <li>
+                <a href="https://www.linkedin.com/in/nicolas-declerck/" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:text-blue-800 font-medium">
+                    LinkedIn — Nicolas Declerck
+                </a>
+            </li>
+        </ul>
+    </section>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Ajout d'une page Contact accessible à `/contact/` avec les liens GitHub et LinkedIn
- Ajout du lien « Contact » dans la navigation du header (après « À propos »)
- 9 tests unitaires couvrant le statut HTTP, le template, le SEO, les liens et la navigation

## Test plan
- [x] La page `/contact/` retourne un statut 200
- [x] Les liens GitHub et LinkedIn sont présents et s'ouvrent dans un nouvel onglet
- [x] Le lien « Contact » apparaît dans la navigation
- [x] La page a un `<title>` et `<meta description>` dynamiques
- [x] 119 tests passent, aucune régression

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)