### PR TITLE
feat: Menu responsive

### DIFF
--- a/apps/core/tests/test_views.py
+++ b/apps/core/tests/test_views.py
@@ -2,6 +2,8 @@ import pytest
 from django.test import Client
 from django.urls import reverse
 
+from apps.accounts.tests.factories import UserFactory
+
 
 @pytest.mark.django_db
 class TestAboutView:
@@ -81,3 +83,48 @@ class TestContactView:
         content = response.content.decode()
         assert "Contact" in content
         assert reverse("contact") in content
+
+
+@pytest.mark.django_db
+class TestResponsiveMenu:
+    def test_hamburger_button_present(self, client: Client):
+        response = client.get(reverse("home"))
+        content = response.content.decode()
+        assert 'id="menu-toggle"' in content
+
+    def test_mobile_menu_present_and_hidden(self, client: Client):
+        response = client.get(reverse("home"))
+        content = response.content.decode()
+        assert 'id="mobile-menu"' in content
+        assert 'id="mobile-menu" class="hidden md:hidden' in content
+
+    def test_mobile_menu_nav_links(self, client: Client):
+        response = client.get(reverse("home"))
+        content = response.content.decode()
+        mobile_menu = content.split('id="mobile-menu"')[1].split("</header>")[0]
+        assert "Articles" in mobile_menu
+        assert "À propos" in mobile_menu
+        assert "Contact" in mobile_menu
+
+    def test_mobile_menu_auth_buttons_anonymous(self, client: Client):
+        response = client.get(reverse("home"))
+        content = response.content.decode()
+        mobile_menu = content.split('id="mobile-menu"')[1].split("</header>")[0]
+        assert "Se connecter" in mobile_menu
+        assert "Créer un compte" in mobile_menu
+
+    def test_mobile_menu_auth_buttons_authenticated(self, client: Client):
+        user = UserFactory()
+        client.force_login(user)
+        response = client.get(reverse("home"))
+        content = response.content.decode()
+        mobile_menu = content.split('id="mobile-menu"')[1].split("</header>")[0]
+        assert "Mon profil" in mobile_menu
+        assert "Ajouter un article" in mobile_menu
+        assert "Se déconnecter" in mobile_menu
+
+    def test_desktop_nav_has_hidden_md_flex(self, client: Client):
+        response = client.get(reverse("home"))
+        content = response.content.decode()
+        assert 'class="hidden md:flex items-center gap-6"' in content
+        assert 'class="hidden md:flex items-center gap-3"' in content

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,13 +11,17 @@
 <body class="bg-white min-h-screen flex flex-col">
     <header class="border-b border-gray-200">
         <div class="max-w-3xl mx-auto px-4 py-4 flex items-center justify-between">
-            <nav class="flex items-center gap-6">
-                <a href="{% url 'home' %}" class="text-base font-semibold text-gray-900 hover:text-black">NICKORP</a>
+            <a href="{% url 'home' %}" class="text-base font-semibold text-gray-900 hover:text-black">NICKORP</a>
+
+            <!-- Navigation desktop -->
+            <nav class="hidden md:flex items-center gap-6">
                 <a href="{% url 'post_list' %}" class="nav-link">Articles</a>
                 <a href="{% url 'about' %}" class="nav-link">À propos</a>
                 <a href="{% url 'contact' %}" class="nav-link">Contact</a>
             </nav>
-            <div class="flex items-center gap-3">
+
+            <!-- Boutons auth desktop -->
+            <div class="hidden md:flex items-center gap-3">
                 {% if user.is_authenticated %}
                 <a href="{% url 'accounts:profile_edit' %}" class="btn-secondary">Mon profil</a>
                 <a href="{% url 'post_create' %}" class="btn-primary">Ajouter un article</a>
@@ -30,8 +34,66 @@
                 <a href="{% url 'accounts:signup' %}" class="btn-primary">Créer un compte</a>
                 {% endif %}
             </div>
+
+            <!-- Bouton hamburger mobile -->
+            <button id="menu-toggle" class="md:hidden inline-flex items-center justify-center p-2 rounded-md text-gray-600 hover:text-gray-900 hover:bg-gray-100" aria-expanded="false" aria-label="Menu de navigation">
+                <svg id="icon-open" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                </svg>
+                <svg id="icon-close" class="hidden h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+            </button>
+        </div>
+
+        <!-- Menu mobile -->
+        <div id="mobile-menu" class="hidden md:hidden border-t border-gray-200 px-4 py-4">
+            <nav class="flex flex-col gap-3">
+                <a href="{% url 'post_list' %}" class="nav-link">Articles</a>
+                <a href="{% url 'about' %}" class="nav-link">À propos</a>
+                <a href="{% url 'contact' %}" class="nav-link">Contact</a>
+            </nav>
+            <div class="mt-4 pt-4 border-t border-gray-200 flex flex-col gap-3">
+                {% if user.is_authenticated %}
+                <a href="{% url 'accounts:profile_edit' %}" class="btn-secondary text-center">Mon profil</a>
+                <a href="{% url 'post_create' %}" class="btn-primary text-center">Ajouter un article</a>
+                <form method="post" action="{% url 'accounts:logout' %}">
+                    {% csrf_token %}
+                    <button type="submit" class="btn-secondary w-full">Se déconnecter</button>
+                </form>
+                {% else %}
+                <a href="{% url 'accounts:login' %}" class="btn-secondary text-center">Se connecter</a>
+                <a href="{% url 'accounts:signup' %}" class="btn-primary text-center">Créer un compte</a>
+                {% endif %}
+            </div>
         </div>
     </header>
+
+    <script>
+        (function () {
+            const toggle = document.getElementById('menu-toggle');
+            const menu = document.getElementById('mobile-menu');
+            const iconOpen = document.getElementById('icon-open');
+            const iconClose = document.getElementById('icon-close');
+
+            toggle.addEventListener('click', function () {
+                const isOpen = !menu.classList.contains('hidden');
+                menu.classList.toggle('hidden');
+                iconOpen.classList.toggle('hidden');
+                iconClose.classList.toggle('hidden');
+                toggle.setAttribute('aria-expanded', !isOpen);
+            });
+
+            menu.querySelectorAll('a').forEach(function (link) {
+                link.addEventListener('click', function () {
+                    menu.classList.add('hidden');
+                    iconOpen.classList.remove('hidden');
+                    iconClose.classList.add('hidden');
+                    toggle.setAttribute('aria-expanded', 'false');
+                });
+            });
+        })();
+    </script>
 
     <main class="flex-1">
         {% block content %}{% endblock %}


### PR DESCRIPTION
## Description

Closes #31

---

## Documentation

### Ce qui a été implémenté
- **`templates/base.html`** : restructuration complète du header pour le responsive
  - Séparation du logo (toujours visible) de la navigation et des boutons auth
  - Navigation desktop : liens masqués sur mobile via `hidden md:flex`
  - Bouton hamburger (`id="menu-toggle"`) visible uniquement sur mobile (`md:hidden`) avec icônes SVG (☰ / ✕)
  - Menu mobile (`id="mobile-menu"`) : panneau vertical caché par défaut, affichant liens de navigation + boutons d'authentification empilés
  - Script JavaScript inline pour le toggle du menu (ouverture/fermeture, changement d'icône, fermeture auto au clic sur un lien)
- **`apps/core/tests/test_views.py`** : 6 nouveaux tests couvrant le menu responsive

### Choix techniques
- **JavaScript vanilla inline** plutôt qu'un fichier externe : le script est minimal (~15 lignes) et spécifique au header.
- **Icônes SVG** pour le hamburger et la croix : pas de dépendance externe, rendu net sur tous les écrans.
- **Breakpoint `md` (768px)** de Tailwind comme seuil de bascule mobile/desktop.
- **`aria-expanded`** sur le bouton hamburger pour l'accessibilité.

### Comment utiliser cette évolution
Aucune configuration nécessaire. Le menu responsive fonctionne automatiquement :
- **Écran < 768px** : le header affiche le logo + un bouton hamburger. Cliquer sur le hamburger ouvre un menu vertical avec tous les liens.
- **Écran ≥ 768px** : comportement inchangé, liens en ligne.

### Points d'attention
- Le toggle JavaScript est inline dans `base.html` — si le template est modifié, vérifier que les IDs `menu-toggle`, `mobile-menu`, `icon-open`, `icon-close` restent cohérents.
- Les comportements JS (toggle, changement d'icône) ne sont pas testés côté serveur — ils nécessiteraient des tests end-to-end (Selenium/Playwright) si besoin.