### PR TITLE
feat: Déplacement avatar

### DIFF
--- a/apps/accounts/tests/test_views.py
+++ b/apps/accounts/tests/test_views.py
@@ -434,3 +434,65 @@ class TestAvatarDeleteView:
         self.client.login(username=self.user.username, password=self.password)
         response = self.client.get(AVATAR_DELETE_URL)
         assert response.status_code == 405
+
+
+@pytest.mark.django_db
+class TestProfileEditAvatarPosition:
+    def setup_method(self):
+        self.client = Client()
+        self.password = "Str0ngP@ss!"
+        self.user = UserFactory(email="avatarpos@example.com", password=self.password)
+
+    def _upload_avatar(self):
+        from io import BytesIO
+
+        from PIL import Image
+
+        img = Image.new("RGB", (100, 100), "red")
+        buf = BytesIO()
+        img.save(buf, format="JPEG")
+        buf.seek(0)
+        avatar = SimpleUploadedFile(
+            "avatar.jpg", buf.read(), content_type="image/jpeg"
+        )
+        self.client.post(
+            PROFILE_EDIT_URL,
+            {"first_name": "", "last_name": "", "avatar": avatar},
+        )
+        self.user.profile.refresh_from_db()
+
+    def test_profile_edit_avatar_displayed_at_top(self):
+        self.client.login(username=self.user.username, password=self.password)
+        self._upload_avatar()
+        response = self.client.get(PROFILE_EDIT_URL)
+        content = response.content.decode()
+        avatar_pos = content.find('alt="Avatar actuel"')
+        h1_pos = content.find("<h1")
+        assert avatar_pos != -1
+        assert h1_pos != -1
+        assert avatar_pos < h1_pos
+
+    def test_profile_edit_no_avatar_no_empty_space(self):
+        self.client.login(username=self.user.username, password=self.password)
+        response = self.client.get(PROFILE_EDIT_URL)
+        content = response.content.decode()
+        assert 'alt="Avatar actuel"' not in content
+
+    def test_profile_edit_avatar_centered(self):
+        self.client.login(username=self.user.username, password=self.password)
+        self._upload_avatar()
+        response = self.client.get(PROFILE_EDIT_URL)
+        content = response.content.decode()
+        avatar_img_pos = content.find('alt="Avatar actuel"')
+        # Find the parent div with centering classes
+        preceding = content[:avatar_img_pos]
+        last_div = preceding.rfind("<div")
+        parent_div = preceding[last_div:]
+        assert "flex" in parent_div
+        assert "justify-center" in parent_div
+
+    def test_profile_edit_form_still_has_file_input(self):
+        self.client.login(username=self.user.username, password=self.password)
+        response = self.client.get(PROFILE_EDIT_URL)
+        content = response.content.decode()
+        assert 'type="file"' in content

--- a/templates/accounts/profile_edit.html
+++ b/templates/accounts/profile_edit.html
@@ -6,6 +6,14 @@
 
 {% block content %}
 <div class="max-w-sm mx-auto px-4 py-16">
+    {% if profile_form.instance.avatar %}
+    <div class="mb-6 flex justify-center">
+        <img src="{{ profile_form.instance.avatar.url }}"
+             alt="Avatar actuel"
+             class="w-20 h-20 rounded-full object-cover">
+    </div>
+    {% endif %}
+
     <h1 class="text-2xl font-bold text-gray-900 text-center mb-8">Modifier mon profil</h1>
 
     {% if messages %}
@@ -61,13 +69,6 @@
             <label for="{{ profile_form.avatar.id_for_label }}" class="form-label">
                 Avatar
             </label>
-            {% if profile_form.instance.avatar %}
-            <div class="mb-2 flex items-center gap-4">
-                <img src="{{ profile_form.instance.avatar.url }}"
-                     alt="Avatar actuel"
-                     class="w-20 h-20 rounded-full object-cover">
-            </div>
-            {% endif %}
             <input type="file"
                    name="{{ profile_form.avatar.html_name }}"
                    id="{{ profile_form.avatar.id_for_label }}"


### PR DESCRIPTION
## Description

Closes #36

Déplace l'avatar en haut de la page de profil (`/comptes/profil/modifier/`) et le centre horizontalement, avant le titre "Modifier mon profil".

---

## Documentation

### Ce qui a été implémenté
- **`templates/accounts/profile_edit.html`** : Déplacement du bloc d'affichage de l'avatar en haut de la page, avant le `<h1>`, avec centrage horizontal via `flex justify-center`.
- **`apps/accounts/tests/test_views.py`** : Ajout de 4 tests dans la classe `TestProfileEditAvatarPosition`.

### Choix techniques
- L'avatar est affiché dans un `<div class="mb-6 flex justify-center">` tout en haut du conteneur principal.
- Le bloc conditionnel `{% if profile_form.instance.avatar %}` garantit qu'aucun espace vide n'apparaît sans avatar.
- Le champ `<input type="file">` reste dans le formulaire pour l'upload.
- Les classes de l'image (`w-20 h-20 rounded-full object-cover`) sont conservées.

### Points d'attention
- Le bouton "Supprimer l'avatar" reste positionné après le formulaire, inchangé.
- Modification purement template — aucun changement de modèle ou de vue.
- 179 tests passent, coverage 99%.