### PR TITLE
feat: Initialiser le Readme

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -153,6 +153,29 @@ pytest --cov=apps
 | `redis` | Cache + broker Celery | 6380 |
 | `celery` | Worker asynchrone | — |
 
+## Mise a jour
+
+### Avec Docker
+
+```bash
+git pull
+docker compose build
+docker compose up -d
+docker compose exec django python manage.py migrate
+npm install
+npx tailwindcss -i ./static/css/input.css -o ./static/css/output.css
+```
+
+### En local
+
+```bash
+git pull
+pip install -r requirements/development.txt
+python manage.py migrate
+npm install
+npx tailwindcss -i ./static/css/input.css -o ./static/css/output.css
+```
+
 ## Commandes utiles
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,1 +1,58 @@
-# test-squad-automation
+# Test Squad Automation — Blog Django
+
+Application de blog multi-utilisateur construite avec Django. Elle permet la publication d'articles avec moderation des commentaires, gestion des profils utilisateurs et pages statiques.
+
+## Fonctionnalites principales
+
+- **Gestion d'articles** : creation, edition, publication avec brouillons, categories et tags
+- **Commentaires avec moderation** : les commentaires sont soumis a validation avant publication
+- **Profils utilisateurs** : inscription, connexion, gestion de profil avec avatar
+- **Pages statiques** : a propos, contact, coming soon
+- **Taches asynchrones** : envoi de notifications via Celery
+- **Interface responsive** : stylisee avec Tailwind CSS
+
+## Stack technique
+
+| Composant | Technologie | Version |
+|-----------|-------------|---------|
+| Backend | Django | 5.x |
+| Base de donnees | PostgreSQL | 16 |
+| Cache / Queue broker | Redis | 7 |
+| Worker asynchrone | Celery | 5.x |
+| CSS | Tailwind CSS | 3.x |
+| Deploiement | Docker + Docker Compose | — |
+
+## Installation
+
+Consultez le [guide d'installation](INSTALL.md) pour les instructions completes (Docker et local).
+
+## Tests
+
+```bash
+pytest --cov=apps
+```
+
+Voir la section [Lancer les tests](INSTALL.md#lancer-les-tests) dans le guide d'installation pour plus de details.
+
+## Structure du projet
+
+```
+project/
+├── config/              # Configuration Django (settings, urls, celery)
+│   └── settings/        # Settings par environnement (base, dev, prod)
+├── apps/
+│   ├── accounts/        # Authentification et profils utilisateurs
+│   ├── blog/            # Articles, categories, tags, commentaires
+│   └── core/            # Pages statiques et utilitaires partages
+├── templates/           # Templates HTML (Tailwind CSS)
+├── static/              # Fichiers statiques (CSS, JS)
+├── media/               # Uploads utilisateurs (images, avatars)
+├── docker/              # Dockerfiles
+├── requirements/        # Dependances Python par environnement
+├── docker-compose.yml
+└── manage.py
+```
+
+## Licence
+
+Projet prive — tous droits reserves.


### PR DESCRIPTION
## Description

Closes #39

---

## Documentation

### Ce qui a ete implemente

- **README.md** : reecrit entierement avec description de l'application, fonctionnalites principales, tableau de stack technique, lien vers INSTALL.md, commande de tests, et arborescence simplifiee du projet
- **INSTALL.md** : ajout d'une section « Mise a jour » avec les procedures Docker et locale (git pull, build, migrations, Tailwind)

### Choix techniques

- Le README ne duplique pas les consignes d'installation, il renvoie vers INSTALL.md via un lien
- La section « Mise a jour » couvre les deux modes (Docker et local) pour etre coherente avec le reste d'INSTALL.md
- Verification de la doc existante : les ports (8001 pour Django, 6380 pour Redis) sont coherents avec docker-compose.yml, aucune erreur detectee

### Comment utiliser cette evolution

Aucune action requise — il suffit de consulter le README.md et INSTALL.md apres merge.

### Points d'attention

- La section Licence dans le README est generique (« Projet prive — tous droits reserves »), a adapter si necessaire

🤖 Generated with [Claude Code](https://claude.com/claude-code)