### PR TITLE
feat: Ajout de blocnotejs

### DIFF
--- a/apps/blog/forms.py
+++ b/apps/blog/forms.py
@@ -1,12 +1,33 @@
 from django import forms
+from django.utils.safestring import mark_safe
 
 from .models import Comment, Post
+
+
+class BlockNoteWidget(forms.HiddenInput):
+    def render(self, name, value, attrs=None, renderer=None):
+        hidden_input = forms.HiddenInput.render(
+            self, name, value, attrs, renderer=renderer
+        )
+        editor_id = f"blocknote-editor-{name}"
+        html = (
+            f'<div id="{editor_id}" class="blocknote-container border'
+            f' border-gray-300 rounded-md min-h-[300px]"></div>'
+            f"{hidden_input}"
+        )
+        return mark_safe(html)
+
+    class Media:
+        js = ("js/dist/blocknote-editor.iife.js",)
 
 
 class PostForm(forms.ModelForm):
     class Meta:
         model = Post
         fields = ("title", "content")
+        widgets = {
+            "content": BlockNoteWidget(),
+        }
 
 
 class CommentForm(forms.ModelForm):

--- a/apps/blog/models.py
+++ b/apps/blog/models.py
@@ -1,6 +1,17 @@
+import bleach
 from django.conf import settings
 from django.db import models
 from django.utils.text import slugify
+
+ALLOWED_TAGS = [
+    "p", "h1", "h2", "h3", "ul", "ol", "li",
+    "strong", "em", "a", "img", "blockquote", "code", "pre",
+    "br", "span", "div",
+]
+ALLOWED_ATTRIBUTES = {
+    "a": ["href", "title", "target", "rel"],
+    "img": ["src", "alt", "title", "width", "height"],
+}
 
 
 class Post(models.Model):
@@ -28,6 +39,15 @@ class Post(models.Model):
 
     def __str__(self):
         return self.title
+
+    @property
+    def content_sanitized(self):
+        return bleach.clean(
+            self.content,
+            tags=ALLOWED_TAGS,
+            attributes=ALLOWED_ATTRIBUTES,
+            strip=True,
+        )
 
     def save(self, *args, **kwargs):
         if not self.slug:

--- a/apps/blog/tests/test_forms.py
+++ b/apps/blog/tests/test_forms.py
@@ -1,6 +1,6 @@
 import pytest
 
-from apps.blog.forms import CommentForm, PostForm
+from apps.blog.forms import BlockNoteWidget, CommentForm, PostForm
 
 
 @pytest.mark.django_db
@@ -18,6 +18,20 @@ class TestPostForm:
         form = PostForm(data={"title": "Un titre", "content": ""})
         assert not form.is_valid()
         assert "content" in form.errors
+
+
+@pytest.mark.django_db
+class TestBlockNoteWidget:
+    def test_post_form_widget_renders_blocknote_container(self):
+        form = PostForm()
+        rendered = form.as_p()
+        assert "blocknote-container" in rendered
+        assert 'id="blocknote-editor-content"' in rendered
+
+    def test_post_form_widget_is_hidden_input(self):
+        form = PostForm()
+        widget = form.fields["content"].widget
+        assert isinstance(widget, BlockNoteWidget)
 
 
 @pytest.mark.django_db

--- a/apps/blog/tests/test_models.py
+++ b/apps/blog/tests/test_models.py
@@ -40,6 +40,30 @@ class TestPostModel:
 
 
 @pytest.mark.django_db
+class TestPostContentSanitization:
+    def test_html_sanitization_strips_script(self):
+        post = PostFactory(content='<p>Hello</p><script>alert("xss")</script>')
+        assert "<script>" not in post.content_sanitized
+        assert "<p>Hello</p>" in post.content_sanitized
+
+    def test_html_sanitization_allows_safe_tags(self):
+        html = "<p><strong>Bold</strong> and <em>italic</em></p>"
+        post = PostFactory(content=html)
+        assert post.content_sanitized == html
+
+    def test_html_sanitization_allows_links(self):
+        html = '<p><a href="https://example.com">Link</a></p>'
+        post = PostFactory(content=html)
+        assert 'href="https://example.com"' in post.content_sanitized
+
+    def test_html_sanitization_strips_onclick(self):
+        html = '<p onclick="alert(1)">Text</p>'
+        post = PostFactory(content=html)
+        assert "onclick" not in post.content_sanitized
+        assert "<p>Text</p>" in post.content_sanitized
+
+
+@pytest.mark.django_db
 class TestCommentModel:
     def test_is_approved_false_by_default(self):
         comment = CommentFactory()

--- a/apps/blog/tests/test_views.py
+++ b/apps/blog/tests/test_views.py
@@ -185,6 +185,23 @@ class TestPostCreateView:
         content = response.content.decode()
         assert "Créez un nouvel article sur le blog." in content
 
+    def test_post_create_with_html_content(self):
+        self.client.login(username=self.user.username, password=self.password)
+        html_content = "<p>Contenu <strong>riche</strong> de l'article</p>"
+        self.client.post(
+            CREATE_URL,
+            {"title": "Article HTML", "content": html_content},
+        )
+        post = Post.objects.get(title="Article HTML")
+        assert post.content == html_content
+
+    def test_create_form_renders_blocknote_container(self):
+        self.client.login(username=self.user.username, password=self.password)
+        response = self.client.get(CREATE_URL)
+        content = response.content.decode()
+        assert "blocknote-container" in content
+        assert "blocknote-editor.iife.js" in content
+
 
 @pytest.mark.django_db
 class TestPostUpdateView:
@@ -261,6 +278,14 @@ class TestPostUpdateView:
         response = self.client.get(self.url)
         content = response.content.decode()
         assert "Modifiez votre article sur le blog." in content
+
+    def test_post_update_loads_existing_html(self):
+        self.post.content = "<p>Contenu HTML existant</p>"
+        self.post.save()
+        self.client.login(username=self.user.username, password=self.password)
+        response = self.client.get(self.url)
+        content = response.content.decode()
+        assert "&lt;p&gt;Contenu HTML existant&lt;/p&gt;" in content or "Contenu HTML existant" in content
 
 
 @pytest.mark.django_db
@@ -545,6 +570,31 @@ class TestPostDetailView:
         content = response.content.decode()
         comments_section = content.split('id="comments-section"')[1]
         assert "Connectez-vous" in comments_section
+
+    def test_post_detail_html_content_rendered(self):
+        post = PostFactory(content="<p>Contenu <strong>riche</strong></p>")
+        response = self.client.get(f"/articles/{post.slug}/")
+        content = response.content.decode()
+        assert "<p>Contenu <strong>riche</strong></p>" in content
+        assert "whitespace-pre-line" not in content.split("leading-relaxed")[1].split("</div>")[0]
+
+    def test_legacy_plain_text_display(self):
+        post = PostFactory(content="Ceci est du texte brut sans HTML.")
+        response = self.client.get(f"/articles/{post.slug}/")
+        content = response.content.decode()
+        assert "Ceci est du texte brut sans HTML." in content
+        assert "whitespace-pre-line" in content
+
+    def test_html_sanitization_in_detail(self):
+        post = PostFactory(
+            content='<p>Safe</p><script>alert("xss")</script>'
+        )
+        response = self.client.get(f"/articles/{post.slug}/")
+        content = response.content.decode()
+        # Extract the article content area (between <article> tags)
+        article_section = content.split("<article>")[1].split("</article>")[0]
+        assert "<script>" not in article_section
+        assert "<p>Safe</p>" in article_section
 
 
 @pytest.mark.django_db

--- a/package.json
+++ b/package.json
@@ -1,8 +1,15 @@
 {
   "name": "blog-django",
   "private": true,
+  "scripts": {
+    "build:js": "vite build"
+  },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.11",
-    "tailwindcss": "^3.4"
+    "tailwindcss": "^3.4",
+    "vite": "^5.0"
+  },
+  "dependencies": {
+    "@blocknote/core": "^0.28"
   }
 }

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,3 +5,4 @@ redis>=5.0
 celery>=5.3
 Pillow>=10.0
 requests>=2.31
+bleach>=6.0

--- a/static/js/src/blocknote-editor.js
+++ b/static/js/src/blocknote-editor.js
@@ -1,0 +1,51 @@
+import { BlockNoteEditor } from "@blocknote/core";
+import "@blocknote/core/style.css";
+
+/**
+ * Initialise un éditeur BlockNote dans le conteneur donné.
+ * Le contenu HTML est synchronisé dans le champ hidden pour soumission du formulaire.
+ */
+async function initEditor(containerEl, hiddenInputEl, initialHTML) {
+  let initialContent;
+
+  if (initialHTML && initialHTML.trim()) {
+    try {
+      initialContent = await BlockNoteEditor.tryParseHTMLToBlocks(initialHTML);
+    } catch {
+      initialContent = undefined;
+    }
+  }
+
+  const editor = BlockNoteEditor.create({ initialContent });
+
+  const editorDiv = document.createElement("div");
+  editorDiv.className = "blocknote-editor";
+  containerEl.appendChild(editorDiv);
+
+  editor.mount(editorDiv);
+
+  async function syncHTML() {
+    const html = await editor.blocksToHTMLLossy();
+    hiddenInputEl.value = html;
+  }
+
+  editor.onEditorContentChange(syncHTML);
+
+  // Synchronisation initiale
+  await syncHTML();
+
+  // S'assurer que le hidden input est à jour au submit
+  const form = hiddenInputEl.closest("form");
+  if (form) {
+    form.addEventListener("submit", async (e) => {
+      e.preventDefault();
+      await syncHTML();
+      form.submit();
+    });
+  }
+
+  return editor;
+}
+
+// Expose globalement pour usage en vanilla JS
+window.initBlockNoteEditor = initEditor;

--- a/templates/blog/post_detail.html
+++ b/templates/blog/post_detail.html
@@ -27,7 +27,13 @@
         <p class="text-sm text-gray-500 mb-8">
             Par {{ post.author.email }} — {{ post.created_at|date:"d/m/Y" }}
         </p>
+        {% with first_char=post.content|make_list|first %}
+        {% if first_char == "<" %}
+        <div class="text-gray-700 leading-relaxed prose prose-gray max-w-none">{{ post.content_sanitized|safe }}</div>
+        {% else %}
         <div class="text-gray-700 leading-relaxed whitespace-pre-line">{{ post.content }}</div>
+        {% endif %}
+        {% endwith %}
     </article>
 
     {% if messages %}

--- a/templates/blog/post_form.html
+++ b/templates/blog/post_form.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load static %}
 
 {% block title %}{{ title }}{% endblock %}
 
@@ -16,7 +17,7 @@
     </div>
     {% endif %}
 
-    <form method="post" novalidate>
+    <form method="post" novalidate id="post-form">
         {% csrf_token %}
 
         <div class="mb-5">
@@ -42,11 +43,7 @@
             <label for="{{ form.content.id_for_label }}" class="form-label">
                 Contenu
             </label>
-            <textarea name="{{ form.content.html_name }}"
-                      id="{{ form.content.id_for_label }}"
-                      rows="10"
-                      required
-                      class="form-input{% if form.content.errors %} border-red-500{% endif %}">{{ form.content.value|default:'' }}</textarea>
+            {{ form.content }}
             {% if form.content.errors %}
             <ul class="errorlist mt-1">
                 {% for error in form.content.errors %}
@@ -65,4 +62,16 @@
         <a href="{% url 'home' %}" class="text-sm text-gray-500 hover:text-black transition-colors">Retour</a>
     </div>
 </div>
+
+<script src="{% static 'js/dist/blocknote-editor.iife.js' %}"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    var container = document.getElementById('blocknote-editor-content');
+    var hiddenInput = document.getElementById('{{ form.content.id_for_label }}');
+    if (container && hiddenInput) {
+        var initialHTML = hiddenInput.value || '';
+        window.initBlockNoteEditor(container, hiddenInput, initialHTML);
+    }
+});
+</script>
 {% endblock %}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,15 @@
+import { defineConfig } from "vite";
+import { resolve } from "path";
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: resolve(__dirname, "static/js/src/blocknote-editor.js"),
+      name: "BlockNoteEditor",
+      fileName: "blocknote-editor",
+      formats: ["iife"],
+    },
+    outDir: "static/js/dist",
+    emptyOutDir: true,
+  },
+});


### PR DESCRIPTION
## Description

Closes #51

---

## Documentation

### Ce qui a été implémenté

- **`apps/blog/forms.py`** : Widget `BlockNoteWidget` (conteneur + champ hidden) pour le `PostForm`
- **`apps/blog/models.py`** : Propriété `content_sanitized` avec `bleach` (whitelist de tags HTML)
- **`static/js/src/blocknote-editor.js`** : Module vanilla JS exposant `initBlockNoteEditor()` pour initialiser BlockNote
- **`templates/blog/post_form.html`** : Intégration du JS compilé et initialisation de l'éditeur
- **`templates/blog/post_detail.html`** : Détection HTML vs texte brut + affichage sanitizé
- **`requirements/base.txt`** : Ajout de `bleach>=6.0`
- **`package.json`** / **`vite.config.js`** : `@blocknote/core` + Vite en mode IIFE

### Choix techniques

1. Stockage HTML direct dans `Post.content` — aucune migration nécessaire
2. Sanitization côté serveur via `bleach` avec whitelist de tags
3. Détection automatique HTML/texte brut pour rétrocompatibilité
4. Widget custom surchargeant `HiddenInput.render()`
5. Vite en IIFE pour rester en vanilla JS

### Comment utiliser

```bash
npm install && npm run build:js
pip install -r requirements/base.txt
```

L'éditeur est disponible sur les pages de création/modification d'articles (raccourcis clavier + commandes slash).

### Points d'attention

- `static/js/dist/blocknote-editor.iife.js` doit être généré via `npm run build:js`
- Les anciens articles texte brut restent affichés tels quels
- La whitelist HTML est dans `apps/blog/models.py` (`ALLOWED_TAGS`, `ALLOWED_ATTRIBUTES`)