### PR TITLE
feat: Ajustement front mobile formulaire article

### DIFF
--- a/templates/blog/post_form.html
+++ b/templates/blog/post_form.html
@@ -40,6 +40,7 @@
                       placeholder="Titre de l'article"
                       required
                       rows="1"
+                      maxlength="{{ form.title.field.max_length }}"
                       oninput="this.style.height='auto';this.style.height=this.scrollHeight+'px';"
                       class="w-full text-2xl sm:text-3xl font-bold text-gray-900 border-0 outline-none focus:ring-0 bg-transparent placeholder-gray-300 p-0 resize-none overflow-hidden break-words{% if form.title.errors %} border-b-2 border-red-500{% endif %}">{{ form.title.value|default:'' }}</textarea>
             {% if form.title.errors %}
@@ -55,7 +56,7 @@
             <label class="sr-only">Contenu</label>
             {{ form.content }}
             <div id="blocknote-editor"
-                 class="{% if form.content.errors %}border border-red-500{% endif %}"></div>
+                 class="border border-gray-300 rounded-md focus-within:border-gray-900 focus-within:ring-1 focus-within:ring-gray-900{% if form.content.errors %} border-red-500{% endif %}"></div>
             <p class="text-xs text-gray-400 mt-1">
                 Raccourcis : <kbd>Ctrl+B</kbd> gras, <kbd>Ctrl+I</kbd> italique, <kbd>/</kbd> pour les blocs (titres, listes, etc.)
             </p>
@@ -83,7 +84,7 @@
 <script type="module" src="{% static 'js/blocknote-editor.js' %}"></script>
 <script>
     document.addEventListener("DOMContentLoaded", function() {
-        var titleEl = document.getElementById("{{ form.title.id_for_label }}");
+        var titleEl = document.getElementById("{{ form.title.id_for_label|escapejs }}");
         if (titleEl) {
             titleEl.style.height = "auto";
             titleEl.style.height = titleEl.scrollHeight + "px";


### PR DESCRIPTION
## Description

Closes #66

---

## Documentation

### Corrections apportées

1. **Marges du contenu BlockNote sur mobile** : Le padding interne du `.bn-editor` a été supprimé (`padding: 0` au lieu de `padding: 0.75rem`). Le conteneur parent `px-4` gère désormais seul l'espacement horizontal, ce qui harmonise les marges sur mobile.

2. **Retour à la ligne du titre** : L'`<input type="text">` a été remplacé par un `<textarea rows="1">` avec :
   - `resize-none overflow-hidden` pour masquer la barre de redimensionnement
   - `break-words` pour forcer le retour à la ligne
   - Auto-resize via `oninput` (à la saisie) et un script `DOMContentLoaded` (au chargement en mode édition)
   - Taille de police responsive : `text-2xl` sur mobile, `text-3xl` sur desktop (`sm:text-3xl`)