### PR TITLE
feat: Ajustement style article

### DIFF
--- a/templates/blog/post_form.html
+++ b/templates/blog/post_form.html
@@ -56,7 +56,7 @@
             <label class="sr-only">Contenu</label>
             {{ form.content }}
             <div id="blocknote-editor"
-                 class="border border-gray-300 rounded-md focus-within:border-gray-900 focus-within:ring-1 focus-within:ring-gray-900{% if form.content.errors %} border-red-500{% endif %}"></div>
+                 class="{% if form.content.errors %}border border-red-500{% endif %}"></div>
             <p class="text-xs text-gray-400 mt-1">
                 Raccourcis : <kbd>Ctrl+B</kbd> gras, <kbd>Ctrl+I</kbd> italique, <kbd>/</kbd> pour les blocs (titres, listes, etc.)
             </p>


### PR DESCRIPTION
## Description

Closes #73

Suppression des bordures et du focus ring sur le champ d'édition d'articles (éditeur BlockNote) pour un rendu « à la Notion », aligné avec le style du champ titre.

---

## Documentation

### Ce qui a été modifié
- **`templates/blog/post_form.html`** : Retrait des classes Tailwind `border border-gray-300 rounded-md focus-within:border-gray-900 focus-within:ring-1 focus-within:ring-gray-900` sur `div#blocknote-editor`.

### Choix techniques
- La bordure conditionnelle d'erreur (`border border-red-500`) reste fonctionnelle en cas d'erreur de validation.
- Le padding interne de l'éditeur était déjà à `0` — aucune modification nécessaire.

### Comment vérifier
1. Accéder à la page de création ou d'édition d'un article
2. Vérifier que le champ de contenu n'a plus de bordure (ni au repos, ni au focus)
3. Vérifier que le contenu est aligné horizontalement avec le titre