### PR TITLE
feat: Afficher le message de modération après ajout de commentaire

### DIFF
--- a/frontend/src/components/blog/PostDetail.jsx
+++ b/frontend/src/components/blog/PostDetail.jsx
@@ -54,7 +54,7 @@ export default function PostDetail() {
   const [refreshKey, setRefreshKey] = useState(0);
 
   useEffect(() => {
-    setLoading(true);
+    if (!post) setLoading(true);
     api.get(`/api/blog/posts/${slug}/`).then((res) => {
       if (res.ok) {
         setPost(res.data);


### PR DESCRIPTION
## Description

Closes #89

**Cause racine :** Après soumission d'un commentaire, `PostDetail` déclenchait `setLoading(true)` lors du refresh des données, causant l'unmount du `CommentForm` et la perte du message de modération.

**Fix :** Ne déclencher le spinner de chargement que lors du chargement initial (`!post`), pas lors des rafraîchissements silencieux.

---

## Documentation

### Fichier modifié
- `frontend/src/components/blog/PostDetail.jsx` — condition `if (!post) setLoading(true)` au lieu de `setLoading(true)` systématique

### Comment vérifier
1. Se connecter et naviguer vers un article publié
2. Soumettre un commentaire
3. Le message « Votre commentaire a été soumis et est en attente de modération. » doit rester visible
4. Le champ de saisie doit être vidé