### PR TITLE
feat: Mise en place de github actions

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -1,0 +1,42 @@
+name: Regression Tests
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  regression-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for recent merges on main
+        id: check-merges
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SINCE=$(date -u -d '24 hours ago' '+%Y-%m-%dT%H:%M:%SZ')
+          echo "Checking for PRs merged on main since $SINCE"
+
+          MERGE_COUNT=$(gh api \
+            "repos/${{ github.repository }}/pulls?state=closed&base=main&sort=updated&direction=desc&per_page=100" \
+            --jq "[.[] | select(.merged_at != null and .merged_at >= \"$SINCE\")] | length")
+
+          echo "merge_count=$MERGE_COUNT" >> "$GITHUB_OUTPUT"
+
+          if [ "$MERGE_COUNT" -eq 0 ]; then
+            echo "No PRs merged on main in the last 24h. Skipping regression tests."
+          else
+            echo "$MERGE_COUNT PR(s) merged on main in the last 24h. Running regression tests."
+          fi
+
+      - name: Run regression tests on VPS
+        if: steps.check-merges.outputs.merge_count != '0'
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: root
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script: |
+            docker exec -i -w /workspace/test-squad-automation claude-worker \
+              claude -p "Exécute le skill .claude/skills/regression-tests/SKILL.md" \
+              --dangerously-skip-permissions --output-format json

--- a/docs/github-actions-setup.md
+++ b/docs/github-actions-setup.md
@@ -1,0 +1,48 @@
+# Configuration GitHub Actions — Tests de non-régression
+
+## Prérequis
+
+- Un VPS avec Docker installé et le container `claude-worker` en cours d'exécution
+- Une clé SSH permettant l'accès au VPS
+- Le repo GitHub avec les permissions d'administration pour configurer les secrets
+
+## Secrets à configurer
+
+Aller dans **Settings → Secrets and variables → Actions → New repository secret** et ajouter les secrets suivants :
+
+| Secret | Description | Exemple |
+|---|---|---|
+| `VPS_HOST` | IP ou nom de domaine du VPS | `192.168.1.100` ou `vps.example.com` |
+| `VPS_SSH_KEY` | Contenu complet de la clé privée SSH (clé qui a accès au VPS) | Contenu de `~/.ssh/id_ed25519` |
+
+> **Note :** `GITHUB_TOKEN` est injecté automatiquement par GitHub Actions. Il ne faut **pas** le créer manuellement.
+
+## Ajouter la clé SSH
+
+1. Copier le contenu de la clé privée :
+   ```bash
+   cat ~/.ssh/id_ed25519
+   ```
+2. Dans GitHub, aller dans **Settings → Secrets and variables → Actions**
+3. Cliquer sur **New repository secret**
+4. Nom : `VPS_SSH_KEY`
+5. Coller le contenu complet de la clé (y compris les lignes `-----BEGIN` et `-----END`)
+6. Cliquer sur **Add secret**
+
+## Ajouter l'hôte du VPS
+
+1. Dans GitHub, aller dans **Settings → Secrets and variables → Actions**
+2. Cliquer sur **New repository secret**
+3. Nom : `VPS_HOST`
+4. Valeur : l'IP ou le domaine du VPS
+5. Cliquer sur **Add secret**
+
+## Fonctionnement du workflow
+
+Le workflow `.github/workflows/regression-tests.yml` :
+
+- Se déclenche **automatiquement chaque nuit à 2h UTC**
+- Peut être **déclenché manuellement** via l'onglet Actions → Regression Tests → Run workflow
+- Vérifie s'il y a eu des PRs mergées sur `main` dans les dernières 24h
+- Si aucun merge : le workflow se termine proprement sans exécuter les tests
+- Si au moins un merge : se connecte au VPS via SSH et lance les tests de non-régression via Claude Code


### PR DESCRIPTION
## Description

Closes #94

Mise en place d'un workflow GitHub Actions qui lance les tests de non-régression front une fois par jour, uniquement s'il y a eu au moins un merge sur `main` dans les dernières 24h.

---

## Documentation

### Fichiers créés
- `.github/workflows/regression-tests.yml` — Workflow avec cron 2h UTC + workflow_dispatch
- `docs/github-actions-setup.md` — Guide de configuration des secrets

### Fonctionnement
1. Déclenchement quotidien à 2h UTC (ou manuel via workflow_dispatch)
2. Vérification des PRs mergées sur `main` dans les dernières 24h via API GitHub
3. Si aucun merge : skip propre avec message dans les logs
4. Si merge détecté : connexion SSH au VPS via `appleboy/ssh-action@v1` et exécution des tests

### Secrets à configurer
| Secret | Description |
|---|---|
| `VPS_HOST` | IP ou domaine du VPS |
| `VPS_SSH_KEY` | Clé privée SSH pour accéder au VPS |

> `GITHUB_TOKEN` est injecté automatiquement.