### PR TITLE
Auto-deploy to production on merge to main

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -27,7 +27,7 @@ jobs:
             docker compose -f docker-compose.prod.yml build
 
             echo "==> Starting services..."
-            docker compose -f docker-compose.prod.yml up -d
+            docker compose -f docker-compose.prod.yml up -d --force-recreate
 
             echo "==> Running database migrations..."
             docker compose -f docker-compose.prod.yml exec -T django python manage.py migrate


### PR DESCRIPTION
## Summary

- Ajoute un workflow GitHub Actions (`deploy-prod.yml`) qui déclenche automatiquement le déploiement sur le VPS à chaque push/merge sur `main` via SSH
- Le déploiement exécute : `git pull`, `docker compose build`, `docker compose up -d --force-recreate`, et `migrate`
- Met à jour `INSTALL.md` : supprime les étapes manuelles `npm install/build` (gérées par le Dockerfile frontend), ajoute le service `frontend` au tableau de production

## Test plan

- [ ] Vérifier que les secrets `VPS_HOST` et `VPS_SSH_KEY` sont configurés dans GitHub Actions
- [ ] Merger une PR sur `main` et vérifier que le workflow se déclenche
- [ ] Vérifier que le site `blog.nickorp.com` est accessible après le déploiement
- [ ] Vérifier que nginx sert bien le nouveau frontend (grâce à `--force-recreate`)

https://claude.ai/code/session_01ESLvDvZ2QQZXqGfTSFB577