### PR TITLE
fix: supprimer les références localhost des TNR pour éviter la confusion

### DIFF
--- a/.claude/skills/regression-tests/SKILL.md
+++ b/.claude/skills/regression-tests/SKILL.md
@@ -22,21 +22,18 @@ Lis le fichier `docs/browser-test-checklist.md` pour récupérer :
 
 ### 1.2 Configuration des URLs cibles
 
-Détermine les URLs à utiliser selon l'environnement. Les variables `BASE_URL`
-et `API_URL` permettent de cibler n'importe quel environnement :
+Les URLs cibles sont **toujours** les URLs de production, sauf si les
+variables d'environnement `BASE_URL` et `API_URL` sont explicitement définies :
 
 ```bash
 BASE_URL="${BASE_URL:-https://blog.nickorp.com}"
 API_URL="${API_URL:-https://blog.nickorp.com}"
 ```
 
-**Valeurs par défaut** (production) :
+**IMPORTANT : ne jamais utiliser `localhost` ou `127.0.0.1`.** Si aucune
+variable d'environnement n'est définie, utiliser obligatoirement :
 - `BASE_URL=https://blog.nickorp.com`
 - `API_URL=https://blog.nickorp.com`
-
-**Développement local** :
-- `BASE_URL=http://localhost:5173`
-- `API_URL=http://localhost:8001`
 
 Toutes les URLs utilisées dans les tests sont construites à partir de
 `BASE_URL` (ex : `${BASE_URL}/comptes/connexion`).

--- a/docs/browser-test-checklist.md
+++ b/docs/browser-test-checklist.md
@@ -15,9 +15,10 @@
 
 > **Note** : Les utilisateurs de test doivent être créés au préalable via l'interface d'inscription ou via le backend Django.
 >
-> **Configuration des URLs** : Les variables `BASE_URL` et `API_URL` permettent de cibler différents environnements :
-> - Production : `BASE_URL=https://blog.nickorp.com` / `API_URL=https://blog.nickorp.com`
-> - Développement local : `BASE_URL=http://localhost:5173` / `API_URL=http://localhost:8001`
+> **Configuration des URLs** : Les variables `BASE_URL` et `API_URL` permettent de cibler différents environnements.
+> Par défaut (si non définies), utiliser les URLs de production :
+> `BASE_URL=https://blog.nickorp.com` / `API_URL=https://blog.nickorp.com`
+> **Ne jamais utiliser `localhost` sauf si explicitement demandé.**
 
 ---
 


### PR DESCRIPTION
Le skill regression-tests listait les URLs localhost comme alternative
de développement, ce qui pouvait amener Claude à les utiliser au lieu
des URLs de production par défaut. Ajout d'une mention explicite de
ne jamais utiliser localhost sauf si demandé.

https://claude.ai/code/session_01AXreqbuEo8i7pe7cBvuahP