### PR TITLE
Changer le reporting TNR : commentaires par section au lieu de mise à jour du corps

### DIFF
--- a/.claude/skills/regression-tests/SKILL.md
+++ b/.claude/skills/regression-tests/SKILL.md
@@ -71,12 +71,10 @@ results = {
 
 ### 1.5 Création de l'issue de suivi GitHub
 
-Crée une issue GitHub dédiée au suivi en temps réel de cette exécution de TNR.
-Le corps de l'issue contient la liste de tous les tests extraits du cahier,
-avec un statut initial `⏳` (en attente).
+Crée une issue GitHub dédiée au suivi de cette exécution de TNR.
+Le corps de l'issue contient uniquement le nombre total de tests à lancer.
 
 ```bash
-# Construire le corps de l'issue avec la liste des tests
 ISSUE_BODY="## 🧪 Tests de non-régression — $(date -u '+%Y-%m-%d %H:%M UTC')
 
 **Environnement :** ${BASE_URL}
@@ -84,28 +82,7 @@ ISSUE_BODY="## 🧪 Tests de non-régression — $(date -u '+%Y-%m-%d %H:%M UTC'
 
 ---
 
-### Progression
-
-| Statut | Test | Section |
-|--------|------|---------|"
-
-# Pour chaque test du cahier, ajouter une ligne :
-# | ⏳ | [ID] Nom du test | Section |
-# Exemple :
-# | ⏳ | [1.1] Affichage du header | Navigation et Layout |
-
-ISSUE_BODY="$ISSUE_BODY
-
----
-
-### Légende
-- ⏳ En attente
-- ✅ Réussi (PASS)
-- ❌ Échoué (FAIL)
-- ⏭️ Ignoré (SKIP)
-
----
-**Total :** {total} tests | ✅ 0 | ❌ 0 | ⏭️ 0"
+**{total} tests** à exécuter."
 
 TRACKING_ISSUE=$(gh issue create \
   --repo nicolasdeclerck/test-squad-automation \
@@ -115,7 +92,7 @@ TRACKING_ISSUE=$(gh issue create \
   --json number --jq '.number')
 ```
 
-Conserve `TRACKING_ISSUE` (numéro de l'issue) pour la mise à jour progressive.
+Conserve `TRACKING_ISSUE` (numéro de l'issue) pour les commentaires de progression.
 
 ---
 
@@ -208,38 +185,33 @@ Pour chaque test exécuté, ajoute une entrée au rapport :
 }
 ```
 
-### 2.6 Mise à jour de l'issue de suivi
+### 2.6 Commentaire de progression sur l'issue de suivi
 
-Après chaque test exécuté, mets à jour le **corps** de l'issue de suivi
-(pas de commentaire) pour refléter la progression en temps réel.
-
-**Actions :**
-
-1. Remplace le statut du test dans le tableau :
-   - `⏳` → `✅` si PASS
-   - `⏳` → `❌` si FAIL (ajouter le détail entre parenthèses)
-   - `⏳` → `⏭️` si SKIP
-2. Met à jour les compteurs en bas de l'issue
-3. Met à jour via `gh issue edit` :
+Après chaque **section** terminée, ajoute un **commentaire** sur l'issue
+de suivi avec les résultats de cette section.
 
 ```bash
-# Reconstruire le corps complet de l'issue avec les statuts mis à jour
-gh issue edit $TRACKING_ISSUE \
+COMMENT_BODY="### {section_name}
+
+| Statut | Test |
+|--------|------|"
+
+# Pour chaque test de la section, ajouter une ligne :
+# | ✅ | [1.1] Affichage du header |
+# | ❌ | [1.2] Navigation responsive — menu burger ne s'ouvre pas |
+# | ⏭️ | [1.3] Test ignoré — Timeout |
+
+COMMENT_BODY="$COMMENT_BODY
+
+**Résultat section :** ✅ {passed} | ❌ {failed} | ⏭️ {skipped}
+**Progression globale :** {tests_done}/{total} tests exécutés"
+
+gh issue comment $TRACKING_ISSUE \
   --repo nicolasdeclerck/test-squad-automation \
-  --body "$UPDATED_BODY"
+  --body "$COMMENT_BODY"
 ```
 
-**Important :** Ne pas mettre à jour après chaque test individuel si cela
-ralentit trop l'exécution. Mettre à jour **par section** (après tous les
-tests d'une même section) est un bon compromis entre suivi temps réel et
-performance.
-
-**Exemple de ligne mise à jour :**
-```
-| ✅ | [1.1] Affichage du header | Navigation et Layout |
-| ❌ | [1.2] Navigation responsive (détail: menu burger ne s'ouvre pas) | Navigation et Layout |
-| ⏭️ | [2.1] Inscription utilisateur | Authentification |
-```
+**Important :** Un commentaire par section, pas par test individuel.
 
 ---
 
@@ -366,14 +338,25 @@ agent-browser close --all
 
 ### 5.2 Finalisation de l'issue de suivi
 
-Met à jour une dernière fois le corps de l'issue de suivi pour marquer
-l'exécution comme terminée :
-
-1. Remplace `**Statut :** 🔄 En cours` par `**Statut :** ✅ Terminé` (ou
-   `**Statut :** ❌ Terminé avec échecs` si des tests ont échoué)
-2. S'assure que tous les compteurs sont à jour
+Met à jour le **corps** de l'issue pour marquer l'exécution comme terminée,
+et ajoute un **commentaire final** avec le bilan.
 
 ```bash
+# Mise à jour du statut dans le corps de l'issue
+FINAL_STATUS="✅ Terminé"
+if [ "$FAILED_COUNT" -gt 0 ]; then
+  FINAL_STATUS="❌ Terminé avec échecs"
+fi
+
+FINAL_BODY="## 🧪 Tests de non-régression — $(date -u '+%Y-%m-%d %H:%M UTC')
+
+**Environnement :** ${BASE_URL}
+**Statut :** ${FINAL_STATUS}
+
+---
+
+**${TOTAL} tests** exécutés — ✅ ${PASSED} | ❌ ${FAILED} | ⏭️ ${SKIPPED}"
+
 gh issue edit $TRACKING_ISSUE \
   --repo nicolasdeclerck/test-squad-automation \
   --body "$FINAL_BODY"


### PR DESCRIPTION
L'issue de suivi contient maintenant uniquement le nombre de tests à lancer
en texte initial. La progression est reportée via des commentaires (un par
section terminée) plutôt qu'en mettant à jour le corps de l'issue.

https://claude.ai/code/session_01X25mJmaKSYQ3LGpfHo1H7r