### PR TITLE
feat: création d'une version à chaque publication

### DIFF
--- a/apps/blog/models.py
+++ b/apps/blog/models.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.db import models
+from django.db.models import Max
 from django.utils import timezone
 from django.utils.text import slugify
 
@@ -43,6 +44,19 @@ class Post(models.Model):
         if not self.published_at:
             self.published_at = timezone.now()
         self.save()
+
+        current_max = self.versions.aggregate(max_num=Max("version_number"))[
+            "max_num"
+        ]
+        next_version = (current_max or 0) + 1
+        PostVersion.objects.create(
+            post=self,
+            version_number=next_version,
+            title=self.title,
+            content=self.content,
+            published_at=timezone.now(),
+            created_by=self.author,
+        )
 
     def save(self, *args, **kwargs):
         if not self.slug:

--- a/apps/blog/tests/test_models.py
+++ b/apps/blog/tests/test_models.py
@@ -7,6 +7,74 @@ from .factories import CommentFactory, PostFactory, PostVersionFactory
 
 
 @pytest.mark.django_db
+class TestPublishCreatesVersion:
+    def _make_draft(self, **kwargs):
+        defaults = {
+            "status": Post.STATUS_DRAFT,
+            "title": "",
+            "content": "",
+            "draft_title": "Mon brouillon",
+            "draft_content": "Contenu du brouillon",
+            "has_draft": True,
+            "published_at": None,
+        }
+        defaults.update(kwargs)
+        return PostFactory(**defaults)
+
+    def test_publish_creates_version(self):
+        post = self._make_draft()
+        post.publish()
+        assert post.versions.count() == 1
+        version = post.versions.first()
+        assert version.version_number == 1
+
+    def test_publish_twice_creates_two_versions(self):
+        post = self._make_draft()
+        post.publish()
+
+        post.draft_title = "Titre mis à jour"
+        post.draft_content = "Contenu mis à jour"
+        post.has_draft = True
+        post.save()
+        post.publish()
+
+        assert post.versions.count() == 2
+        version_numbers = list(
+            post.versions.order_by("version_number").values_list(
+                "version_number", flat=True
+            )
+        )
+        assert version_numbers == [1, 2]
+
+    def test_version_content_matches_published(self):
+        post = self._make_draft(
+            draft_title="Titre spécifique",
+            draft_content="Contenu spécifique",
+        )
+        post.publish()
+        version = post.versions.first()
+        assert version.title == "Titre spécifique"
+        assert version.content == "Contenu spécifique"
+        assert version.created_by == post.author
+        assert version.published_at is not None
+
+    def test_publish_preserves_existing_behavior(self):
+        post = self._make_draft(
+            draft_title="Titre final",
+            draft_content="Contenu final",
+        )
+        post.publish()
+        post.refresh_from_db()
+        assert post.title == "Titre final"
+        assert post.content == "Contenu final"
+        assert post.status == Post.STATUS_PUBLISHED
+        assert post.has_draft is False
+        assert post.draft_title == ""
+        assert post.draft_content == ""
+        assert post.published_at is not None
+
+
+@pytest.mark.django_db
 class TestPostModel:
     def test_create_post(self):
         post = PostFactory()


### PR DESCRIPTION
## Description

Closes #111

Modifie `Post.publish()` pour créer automatiquement une `PostVersion` après chaque publication, avec calcul incrémental du `version_number`.

---

## Documentation

### Ce qui a été implémenté
- **`apps/blog/models.py`** : Modification de `Post.publish()` pour créer une `PostVersion` après chaque `save()`
- **`apps/blog/tests/test_models.py`** : 4 nouveaux tests (`TestPublishCreatesVersion`)

### Choix techniques
- `self.versions.aggregate(Max('version_number'))` pour calculer le prochain numéro
- `published_at` de la version = `timezone.now()` au moment de la publication

### Tests ajoutés
- `test_publish_creates_version` — première publication → version_number=1
- `test_publish_twice_creates_two_versions` — deux publications → versions 1 et 2
- `test_version_content_matches_published` — contenu version == contenu publié
- `test_publish_preserves_existing_behavior` — non-régression du comportement existant