### PR TITLE
fix: copy package-lock.json and use npm ci in frontend Dockerfile

### DIFF
--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -2,8 +2,8 @@ FROM node:20-alpine AS build
 
 WORKDIR /app
 
-COPY frontend/package.json ./
-RUN npm install
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
 
 COPY frontend/ .
 RUN npm run build


### PR DESCRIPTION
Without the lockfile, npm install resolves latest versions which causes
a peer dependency conflict (@mantine/notifications@9 requires
@mantine/core@9 but project uses @mantine/core@7). Using npm ci with
the lockfile ensures reproducible builds.

https://claude.ai/code/session_012FmffWBCVptebPivdpuURW