### PR TITLE
feat: TNR en environnement Docker éphémère local

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,7 @@
         "@blocknote/mantine": "^0.24.2",
         "@blocknote/react": "^0.24.2",
         "@mantine/core": "^7.17.4",
-        "@mantine/notifications": "^9.0.1",
+        "@mantine/notifications": "^7.17.4",
         "dompurify": "^3.2.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -997,28 +997,28 @@
       }
     },
     "node_modules/@mantine/notifications": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@mantine/notifications/-/notifications-9.0.1.tgz",
-      "integrity": "sha512-og/RfURurEwTISUmgN/wcjlIE1+OxkCgcmUDZ1Jinfm1efJ8ywXl1zf/fa7/VVN4O/xZl+HMhN46OoCnW3+/bw==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@mantine/notifications/-/notifications-7.17.8.tgz",
+      "integrity": "sha512-/YK16IZ198W6ru/IVecCtHcVveL08u2c8TbQTu/2p26LSIM9AbJhUkrU6H+AO0dgVVvmdmNdvPxcJnfq3S9TMg==",
       "license": "MIT",
       "dependencies": {
-        "@mantine/store": "9.0.1",
+        "@mantine/store": "7.17.8",
         "react-transition-group": "4.4.5"
       },
       "peerDependencies": {
-        "@mantine/core": "9.0.1",
-        "@mantine/hooks": "9.0.1",
-        "react": "^19.2.0",
-        "react-dom": "^19.2.0"
+        "@mantine/core": "7.17.8",
+        "@mantine/hooks": "7.17.8",
+        "react": "^18.x || ^19.x",
+        "react-dom": "^18.x || ^19.x"
       }
     },
     "node_modules/@mantine/store": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@mantine/store/-/store-9.0.1.tgz",
-      "integrity": "sha512-7jn/tX6qC71zd8Hcr/m/kQT7wCp87nvUM3p9OoJ2qX13oNCrMEXRtimYwqkOBK5Vx2hNApQY5KF183+arHU6NA==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@mantine/store/-/store-7.17.8.tgz",
+      "integrity": "sha512-/FrB6PAVH4NEjQ1dsc9qOB+VvVlSuyjf4oOOlM9gscPuapDP/79Ryq7JkhHYfS55VWQ/YUlY24hDI2VV+VptXg==",
       "license": "MIT",
       "peerDependencies": {
-        "react": "^19.2.0"
+        "react": "^18.x || ^19.x"
       }
     },
     "node_modules/@mantine/utils": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "@blocknote/mantine": "^0.24.2",
     "@blocknote/react": "^0.24.2",
     "@mantine/core": "^7.17.4",
-    "@mantine/notifications": "^9.0.1",
+    "@mantine/notifications": "^7.17.4",
     "dompurify": "^3.2.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",


### PR DESCRIPTION
## Summary

- Ajout d'un environnement Docker éphémère (`docker-compose.test.yml`) identique à la prod (gunicorn, nginx, frontend buildé, PostgreSQL, Redis, Celery) mais accessible uniquement sur `localhost:8080`
- Script `scripts/tnr-docker.sh` pour gérer le cycle de vie (up/seed/down) avec seed automatique des utilisateurs de test
- Mise à jour du workflow GitHub Actions pour lancer les TNR sur l'environnement éphémère au lieu de la prod, avec teardown automatique
- Support du dispatch manuel avec choix de branche via le dropdown GitHub
- Fix du conflit npm `@mantine/notifications` (v9 → v7 pour matcher `@mantine/core`)
- Fix du frontend Dockerfile : copie du `package-lock.json` + `npm ci` pour des builds reproductibles

## Fichiers ajoutés/modifiés

| Fichier | Rôle |
|---------|------|
| `docker-compose.test.yml` | Compose prod-like, nginx sur localhost:8080, DB sur tmpfs |
| `docker/nginx/nginx.test.conf` | Nginx pour localhost (pas blog.nickorp.com) |
| `config/settings/testing.py` | Settings prod sans contraintes HTTPS |
| `.env.test` | Variables d'env pour l'environnement éphémère |
| `scripts/tnr-docker.sh` | Script orchestration (up/seed/down) |
| `.github/workflows/regression-tests.yml` | Workflow mis à jour |
| `.claude/skills/regression-tests/SKILL.md` | Doc mode Docker local |
| `docker/frontend/Dockerfile` | Fix npm ci + package-lock |
| `frontend/package.json` | Fix @mantine/notifications |

## Test plan

- [ ] Lancer le workflow manuellement depuis Actions > Regression Tests (branche feature)
- [ ] Vérifier que l'environnement Docker démarre correctement
- [ ] Vérifier que les TNR s'exécutent contre localhost et non contre la prod
- [ ] Vérifier que le teardown nettoie tout (containers, volumes, network)

https://claude.ai/code/session_012FmffWBCVptebPivdpuURW