### PR TITLE
feat: ajouter lien Accueil dans le header

### DIFF
--- a/frontend/src/components/layout/Header.jsx
+++ b/frontend/src/components/layout/Header.jsx
@@ -37,6 +37,9 @@ export default function Header() {
 
         {/* Navigation desktop */}
         <nav className="hidden md:flex items-center gap-6">
+          <Link to="/" className="nav-link">
+            Accueil
+          </Link>
           <Link to="/articles" className="nav-link">
             Articles
           </Link>
@@ -146,6 +149,13 @@ export default function Header() {
       {mobileOpen && (
         <div className="md:hidden border-t border-gray-200 px-4 py-4">
           <nav className="flex flex-col gap-3">
+            <Link
+              to="/"
+              className="nav-link"
+              onClick={() => setMobileOpen(false)}
+            >
+              Accueil
+            </Link>
             <Link
               to="/articles"
               className="nav-link"


### PR DESCRIPTION
## Description

Closes #129

Le header ne contenait pas de lien "Accueil". Seul le logo NICKORP permettait de retourner à la page d'accueil, ce qui n'est pas conforme au cahier de tests de non-régression (test 1.1).

---

## Modifications

- **Fichier modifié :** `frontend/src/components/layout/Header.jsx`
- Ajout du lien "Accueil" (`<Link to="/">`) en première position dans la navigation desktop
- Ajout du lien "Accueil" en première position dans la navigation mobile

## Comment vérifier

- Ouvrir la page d'accueil et vérifier que "Accueil" apparaît dans le header desktop
- En mode mobile (< 768px), ouvrir le menu burger et vérifier que "Accueil" est le premier lien
- Ordre attendu : Accueil, Articles, À propos, Contact