### PR TITLE
fix: migrate to createBrowserRouter to fix useBlocker crash

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,7 +1,12 @@
 import { MantineProvider } from "@mantine/core";
 import { Notifications } from "@mantine/notifications";
 import { HelmetProvider } from "react-helmet-async";
-import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
+import {
+  createBrowserRouter,
+  Navigate,
+  Outlet,
+  RouterProvider,
+} from "react-router-dom";
 import LoginForm from "./components/accounts/LoginForm";
 import ProfileEdit from "./components/accounts/ProfileEdit";
 import SignupForm from "./components/accounts/SignupForm";
@@ -25,96 +30,99 @@ function ProtectedRoute({ children }) {
   return children;
 }
 
-function AppRoutes() {
+function AuthLayout() {
   return (
-    <Routes>
-      <Route element={<Layout />}>
-        <Route path="/" element={<PostList isHome />} />
-        <Route path="/articles" element={<PostList />} />
-        <Route
-          path="/articles/mes-brouillons"
-          element={
-            <ProtectedRoute>
-              <MyDrafts />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/articles/creer"
-          element={
-            <ProtectedRoute>
-              <PostForm />
-            </ProtectedRoute>
-          }
-        />
-        <Route path="/articles/:slug" element={<PostDetail />} />
-        <Route
-          path="/articles/:slug/versions"
-          element={
-            <ProtectedRoute>
-              <VersionHistory />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/articles/:slug/versions/:versionNumber"
-          element={
-            <ProtectedRoute>
-              <VersionDetail />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/articles/:slug/modifier"
-          element={
-            <ProtectedRoute>
-              <PostForm />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/articles/:slug/supprimer"
-          element={
-            <ProtectedRoute>
-              <PostDelete />
-            </ProtectedRoute>
-          }
-        />
-        <Route path="/comptes/connexion" element={<LoginForm />} />
-        <Route path="/comptes/inscription" element={<SignupForm />} />
-        <Route
-          path="/comptes/profil/modifier"
-          element={
-            <ProtectedRoute>
-              <ProfileEdit />
-            </ProtectedRoute>
-          }
-        />
-        <Route path="/a-propos" element={<About />} />
-        <Route path="/contact" element={<Contact />} />
-        <Route
-          path="/suivi-des-devs"
-          element={
-            <ProtectedRoute>
-              <DevTracking />
-            </ProtectedRoute>
-          }
-        />
-      </Route>
-    </Routes>
+    <AuthProvider>
+      <Layout />
+    </AuthProvider>
   );
 }
+
+const router = createBrowserRouter([
+  {
+    element: <AuthLayout />,
+    children: [
+      { path: "/", element: <PostList isHome /> },
+      { path: "/articles", element: <PostList /> },
+      {
+        path: "/articles/mes-brouillons",
+        element: (
+          <ProtectedRoute>
+            <MyDrafts />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: "/articles/creer",
+        element: (
+          <ProtectedRoute>
+            <PostForm />
+          </ProtectedRoute>
+        ),
+      },
+      { path: "/articles/:slug", element: <PostDetail /> },
+      {
+        path: "/articles/:slug/versions",
+        element: (
+          <ProtectedRoute>
+            <VersionHistory />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: "/articles/:slug/versions/:versionNumber",
+        element: (
+          <ProtectedRoute>
+            <VersionDetail />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: "/articles/:slug/modifier",
+        element: (
+          <ProtectedRoute>
+            <PostForm />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: "/articles/:slug/supprimer",
+        element: (
+          <ProtectedRoute>
+            <PostDelete />
+          </ProtectedRoute>
+        ),
+      },
+      { path: "/comptes/connexion", element: <LoginForm /> },
+      { path: "/comptes/inscription", element: <SignupForm /> },
+      {
+        path: "/comptes/profil/modifier",
+        element: (
+          <ProtectedRoute>
+            <ProfileEdit />
+          </ProtectedRoute>
+        ),
+      },
+      { path: "/a-propos", element: <About /> },
+      { path: "/contact", element: <Contact /> },
+      {
+        path: "/suivi-des-devs",
+        element: (
+          <ProtectedRoute>
+            <DevTracking />
+          </ProtectedRoute>
+        ),
+      },
+    ],
+  },
+]);
 
 export default function App() {
   return (
     <MantineProvider>
       <Notifications position="top-right" />
       <HelmetProvider>
-        <BrowserRouter>
-          <AuthProvider>
-            <AppRoutes />
-          </AuthProvider>
-        </BrowserRouter>
+        <RouterProvider router={router} />
       </HelmetProvider>
     </MantineProvider>
   );


### PR DESCRIPTION
## Summary

- **Bug** : Les pages de création et d'édition d'articles (`/articles/creer`, `/articles/:slug/modifier`) affichaient une page blanche sur blog.nickorp.com. L'app React crashait entièrement sans message d'erreur visible.
- **Cause racine** : `PostForm.jsx` utilise le hook `useBlocker` de React Router (pour flusher l'autosave avant navigation). Ce hook nécessite un **data router** (`createBrowserRouter`), mais l'app utilisait `<BrowserRouter>` qui ne fournit pas le `DataRouterContext` nécessaire. React Router lançait une erreur fatale qui démontait tout l'arbre React.
- **Correction** : Migration de `<BrowserRouter>` vers `createBrowserRouter` + `<RouterProvider>`. Les routes sont définies en objet de configuration. `AuthProvider` est intégré via un composant `AuthLayout` qui wrape le `Layout` existant.

## Test plan

- [ ] Vérifier que la page d'accueil (`/`) fonctionne
- [ ] Vérifier que la page de création d'article (`/articles/creer`) s'affiche correctement avec l'éditeur BlockNote
- [ ] Vérifier que la page d'édition d'article (`/articles/:slug/modifier`) s'affiche correctement
- [ ] Vérifier que l'autosave fonctionne en mode édition
- [ ] Vérifier que la navigation entre pages fonctionne (liens, retour)
- [ ] Vérifier que la protection des routes (redirection vers login) fonctionne
- [ ] Vérifier que le `useBlocker` flushe bien l'autosave avant navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)