### PR TITLE
Replace Unicode escape sequence with literal character in comment placeholder

### DIFF
--- a/frontend/src/components/blog/CommentForm.jsx
+++ b/frontend/src/components/blog/CommentForm.jsx
@@ -63,7 +63,7 @@ export default function CommentForm({ slug, onCommentAdded }) {
             value={content}
             onChange={(e) => setContent(e.target.value)}
             rows={4}
-            placeholder="\u00c9crivez votre commentaire..."
+            placeholder="Écrivez votre commentaire..."
             className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-gray-900"
           />
           {error && <p className="text-red-600 text-sm mt-1">{error}</p>}


### PR DESCRIPTION
## Summary
Updated the comment form placeholder text to use a literal Unicode character instead of an escape sequence for improved code readability.

## Changes
- Replaced the Unicode escape sequence `\u00c9crivez votre commentaire...` with the literal character `Écrivez votre commentaire...` in the CommentForm component's textarea placeholder

## Details
This change improves code maintainability by using the actual accented character (É) directly in the source code rather than its Unicode escape sequence equivalent. The functionality remains identical, but the code is now more readable and easier to understand at a glance.

https://claude.ai/code/session_01SjFo1P1vsdp8JhRZsLrxy4