### PR TITLE
fix: Page de consultation des versions cassée

### DIFF
--- a/frontend/src/components/blog/VersionDetail.jsx
+++ b/frontend/src/components/blog/VersionDetail.jsx
@@ -120,9 +120,7 @@ export default function VersionDetail() {
   return (
     <div className="max-w-3xl mx-auto px-4 py-12">
       <Helmet>
-        <title>
-          Version {version.version_number} — {version.title}
-        </title>
+        <title>{`Version ${version.version_number} — ${version.title}`}</title>
       </Helmet>
 
       <div className="mb-8">


### PR DESCRIPTION
## Description

Closes #153

Le composant `VersionDetail.jsx` utilisait une interpolation JSX dans le `<title>` de React Helmet, ce qui produisait un tableau de nœuds au lieu d'une chaîne de caractères. Remplacement par un template literal ES6.

**Avant :**
```jsx
<title>
  Version {version.version_number} — {version.title}
</title>
```

**Après :**
```jsx
<title>{`Version ${version.version_number} — ${version.title}`}</title>
```

---

## Documentation

### Ce qui a été implémenté
- **Fichier modifié** : `frontend/src/components/blog/VersionDetail.jsx` (ligne 122-124)

### Comment vérifier
1. Se connecter en tant qu'auteur d'un article publié ayant des versions
2. Naviguer vers `/articles/{slug}/versions/{n}`
3. La page s'affiche sans erreur Helmet
4. Le titre de l'onglet affiche "Version N — Titre"