### PR TITLE
feat: retirer la zone commentaire sur les brouillons

### DIFF
--- a/docs/browser-test-checklist.md
+++ b/docs/browser-test-checklist.md
@@ -387,6 +387,7 @@
   - Le titre du brouillon est affiché correctement
   - Le contenu du brouillon est affiché correctement (rendu BlockNote non vide)
   - Les boutons d'action (Modifier, Supprimer) sont visibles pour l'auteur superutilisateur
+  - La zone de commentaires (formulaire + liste) n'est PAS affichée
 
 ---
 

--- a/frontend/src/components/blog/PostDetail.jsx
+++ b/frontend/src/components/blog/PostDetail.jsx
@@ -280,23 +280,25 @@ export default function PostDetail() {
         </div>
 
         {/* Commentaires — colonne droite en desktop, sous l'article en mobile */}
-        <div className="mt-10 lg:mt-0 lg:w-80 lg:shrink-0">
-          <div className="lg:sticky lg:top-8">
-            <h2 className="text-lg font-semibold text-gray-900 mb-4">Commentaires</h2>
+        {post.status !== "draft" && (
+          <div className="mt-10 lg:mt-0 lg:w-80 lg:shrink-0">
+            <div className="lg:sticky lg:top-8">
+              <h2 className="text-lg font-semibold text-gray-900 mb-4">Commentaires</h2>
 
-            <CommentForm
-              slug={post.slug}
-              onCommentAdded={() => setRefreshKey((k) => k + 1)}
-            />
-
-            <div className="mt-6">
-              <CommentSection
-                comments={post.approved_comments}
+              <CommentForm
                 slug={post.slug}
+                onCommentAdded={() => setRefreshKey((k) => k + 1)}
               />
+
+              <div className="mt-6">
+                <CommentSection
+                  comments={post.approved_comments}
+                  slug={post.slug}
+                />
+              </div>
             </div>
           </div>
-        </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Description

Closes #172

Lorsqu'on consulte un brouillon non publié, la zone de commentaire (formulaire + liste) était affichée inutilement. Cette PR ajoute une condition pour la masquer quand `post.status === "draft"`.

---

## Documentation

### Ce qui a été implémenté
- **`frontend/src/components/blog/PostDetail.jsx`** : Condition `post.status !== "draft"` autour de la zone commentaire complète.
- **`docs/browser-test-checklist.md`** : Vérification ajoutée au scénario 6.4.

### Choix techniques
- Condition au niveau du conteneur englobant (titre H2 + formulaire + liste) pour ne laisser aucun résidu.
- Utilise le champ `post.status` déjà disponible, aucune requête API supplémentaire.

### Points d'attention
- Modification purement frontend, aucun impact backend.
- L'API interdit déjà la création de commentaires sur les brouillons côté serveur.