### PR TITLE
feat: ajout de l'email dans la page de profil

### DIFF
--- a/apps/accounts/forms.py
+++ b/apps/accounts/forms.py
@@ -71,11 +71,22 @@ class LoginForm(AuthenticationForm):
 class UserForm(forms.ModelForm):
     class Meta:
         model = User
-        fields = ("first_name", "last_name")
+        fields = ("first_name", "last_name", "email")
         labels = {
             "first_name": "Prénom",
             "last_name": "Nom",
+            "email": "Adresse email",
         }
+
+    def clean_email(self):
+        email = self.cleaned_data.get("email")
+        if (
+            User.objects.filter(email__iexact=email)
+            .exclude(pk=self.instance.pk)
+            .exists()
+        ):
+            raise forms.ValidationError("Un compte avec cet email existe déjà.")
+        return email
 
 
 class ProfileForm(forms.ModelForm):

--- a/apps/accounts/serializers.py
+++ b/apps/accounts/serializers.py
@@ -22,7 +22,7 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ("id", "username", "email", "first_name", "last_name", "avatar", "is_superuser")
-        read_only_fields = ("id", "username", "is_superuser")
+        read_only_fields = ("id", "username", "email", "is_superuser")
 
     def get_avatar(self, obj):
         if hasattr(obj, "profile") and obj.profile.avatar:

--- a/apps/accounts/serializers.py
+++ b/apps/accounts/serializers.py
@@ -22,7 +22,7 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ("id", "username", "email", "first_name", "last_name", "avatar", "is_superuser")
-        read_only_fields = ("id", "username", "email", "is_superuser")
+        read_only_fields = ("id", "username", "is_superuser")
 
     def get_avatar(self, obj):
         if hasattr(obj, "profile") and obj.profile.avatar:

--- a/apps/accounts/tests/test_api.py
+++ b/apps/accounts/tests/test_api.py
@@ -165,6 +165,81 @@ class TestProfileUpdateAPI:
 
 
 @pytest.mark.django_db
+class TestProfileUpdateEmailAPI:
+    def setup_method(self):
+        self.client = Client()
+
+    def test_update_email(self):
+        from django.test.client import MULTIPART_CONTENT, encode_multipart
+
+        user = UserFactory(email="old@example.com")
+        self.client.force_login(user)
+        response = self.client.put(
+            "/api/accounts/profile/",
+            data=encode_multipart(
+                "BoUnDaRyStRiNg",
+                {"first_name": "Jean", "last_name": "Dupont", "email": "new@example.com"},
+            ),
+            content_type=MULTIPART_CONTENT,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["email"] == "new@example.com"
+
+    def test_update_email_duplicate(self):
+        from django.test.client import MULTIPART_CONTENT, encode_multipart
+
+        UserFactory(email="taken@example.com")
+        user = UserFactory(email="mine@example.com")
+        self.client.force_login(user)
+        response = self.client.put(
+            "/api/accounts/profile/",
+            data=encode_multipart(
+                "BoUnDaRyStRiNg",
+                {"first_name": "Jean", "last_name": "Dupont", "email": "taken@example.com"},
+            ),
+            content_type=MULTIPART_CONTENT,
+        )
+        assert response.status_code == 400
+        data = response.json()
+        assert "email" in data
+
+    def test_update_email_invalid_format(self):
+        from django.test.client import MULTIPART_CONTENT, encode_multipart
+
+        user = UserFactory(email="valid@example.com")
+        self.client.force_login(user)
+        response = self.client.put(
+            "/api/accounts/profile/",
+            data=encode_multipart(
+                "BoUnDaRyStRiNg",
+                {"first_name": "Jean", "last_name": "Dupont", "email": "invalid-email"},
+            ),
+            content_type=MULTIPART_CONTENT,
+        )
+        assert response.status_code == 400
+        data = response.json()
+        assert "email" in data
+
+    def test_update_keeps_same_email(self):
+        from django.test.client import MULTIPART_CONTENT, encode_multipart
+
+        user = UserFactory(email="same@example.com")
+        self.client.force_login(user)
+        response = self.client.put(
+            "/api/accounts/profile/",
+            data=encode_multipart(
+                "BoUnDaRyStRiNg",
+                {"first_name": "Jean", "last_name": "Dupont", "email": "same@example.com"},
+            ),
+            content_type=MULTIPART_CONTENT,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["email"] == "same@example.com"
+
+
+@pytest.mark.django_db
 class TestProfileUpdateAvatarValidationAPI:
     def setup_method(self):
         self.client = Client()

--- a/docs/browser-test-checklist.md
+++ b/docs/browser-test-checklist.md
@@ -444,10 +444,26 @@
 - **URL** : `/comptes/profil/modifier`
 - **Action** : Modifier le prénom et/ou le nom de famille, soumettre
 - **Vérifications** :
-  - Le formulaire affiche les champs : prénom, nom de famille
+  - Le formulaire affiche les champs : prénom, nom de famille, email
   - Les champs sont pré-remplis avec les valeurs actuelles
   - Un message de succès s'affiche après la sauvegarde
   - Les modifications sont reflétées dans le header (nom/avatar)
+
+### 8.5 — [AUTH] Modification de l'email
+
+- **URL** : `/comptes/profil/modifier`
+- **Action** : Modifier l'adresse email avec une adresse valide, soumettre
+- **Vérifications** :
+  - Le champ email est pré-rempli avec l'adresse actuelle
+  - Après modification, un message de succès s'affiche
+  - Le champ email affiche la nouvelle adresse après rechargement
+
+### 8.6 — [AUTH] Modification de l'email — Validation
+
+- **URL** : `/comptes/profil/modifier`
+- **Actions et vérifications** :
+  - Email invalide (format incorrect) → message d'erreur affiché
+  - Email déjà utilisé par un autre utilisateur → message d'erreur affiché
 
 ### 8.2 — [AUTH] Upload d'avatar
 

--- a/frontend/src/components/accounts/ProfileEdit.jsx
+++ b/frontend/src/components/accounts/ProfileEdit.jsx
@@ -8,6 +8,7 @@ export default function ProfileEdit() {
   const { user, updateProfile, deleteAvatar } = useAuth();
   const [firstName, setFirstName] = useState(user?.first_name || "");
   const [lastName, setLastName] = useState(user?.last_name || "");
+  const [email, setEmail] = useState(user?.email || "");
   const [avatar, setAvatar] = useState(null);
   const [errors, setErrors] = useState({});
   const [successMsg, setSuccessMsg] = useState("");
@@ -22,6 +23,7 @@ export default function ProfileEdit() {
     const formData = new FormData();
     formData.append("first_name", firstName);
     formData.append("last_name", lastName);
+    formData.append("email", email);
     if (avatar) {
       formData.append("avatar", avatar);
     }
@@ -125,6 +127,27 @@ export default function ProfileEdit() {
           />
           {errors.last_name &&
             errors.last_name.map((err, i) => (
+              <p key={i} className="form-error">
+                {err}
+              </p>
+            ))}
+        </div>
+
+        <div className="mb-4">
+          <label htmlFor="email" className="form-label">
+            Adresse email
+          </label>
+          <input
+            type="email"
+            id="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className={`form-input${
+              errors.email ? " border-red-500" : ""
+            }`}
+          />
+          {errors.email &&
+            errors.email.map((err, i) => (
               <p key={i} className="form-error">
                 {err}
               </p>

--- a/frontend/src/components/accounts/ProfileEdit.jsx
+++ b/frontend/src/components/accounts/ProfileEdit.jsx
@@ -68,7 +68,7 @@ export default function ProfileEdit() {
 
       <Helmet>
         <title>Modifier mon profil</title>
-        <meta name="description" content="Modifiez votre profil : pr\u00e9nom, nom et avatar." />
+        <meta name="description" content="Modifiez votre profil : pr\u00e9nom, nom, email et avatar." />
       </Helmet>
       <h1 className="text-2xl font-bold text-gray-900 text-center mb-8">
         Modifier mon profil


### PR DESCRIPTION
## Description

Closes #177

Permet à l'utilisateur de voir et modifier son adresse email dans la page de profil (`/comptes/profil/modifier`).

---

## Documentation

### Ce qui a été implémenté
- **apps/accounts/forms.py** : Ajout du champ `email` au `UserForm` avec validation d'unicité (case-insensitive)
- **apps/accounts/serializers.py** : Retrait de `email` des `read_only_fields` du `UserSerializer`
- **frontend/src/components/accounts/ProfileEdit.jsx** : Ajout du champ email avec état, envoi dans le FormData, et affichage des erreurs
- **apps/accounts/tests/test_api.py** : 4 nouveaux tests (modification email, email dupliqué, format invalide, même email conservé)

### Choix techniques
- Validation d'unicité dans `UserForm.clean_email()` (cohérent avec l'architecture existante `ProfileUpdateAPIView` → `UserForm`)
- Validation case-insensitive (`email__iexact`) cohérente avec le pattern de `SignUpForm`

### Tests
- 184 tests passés, 98% de couverture
- 4 nouveaux tests spécifiques à la modification d'email