### PR TITLE
feat: compression automatique des images d'articles (#184)

### DIFF
--- a/apps/blog/models.py
+++ b/apps/blog/models.py
@@ -1,7 +1,9 @@
+import os
 from io import BytesIO
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
+from django.core.files.base import ContentFile
 from django.db import models
 from django.db.models import Max
 from django.utils import timezone
@@ -44,6 +46,9 @@ def validate_post_image(image):
 
 
 class PostImage(models.Model):
+    IMAGE_MAX_SIZE = (1920, 1080)
+    IMAGE_JPEG_QUALITY = 85
+
     image = models.ImageField(
         upload_to="blog/images/",
         validators=[validate_post_image],
@@ -57,6 +62,38 @@ class PostImage(models.Model):
 
     def __str__(self):
         return f"Image {self.pk} par {self.uploaded_by}"
+
+    def _compress_image(self):
+        """Compress and resize image to JPEG, max 1920x1080."""
+        with Image.open(self.image) as img:
+            if img.mode in ("RGBA", "LA", "P"):
+                rgba = img.convert("RGBA")
+                background = Image.new("RGB", rgba.size, (255, 255, 255))
+                background.paste(rgba, mask=rgba.split()[3])
+                result = background
+            elif img.mode != "RGB":
+                result = img.convert("RGB")
+            else:
+                result = img.copy()
+
+            result.thumbnail(self.IMAGE_MAX_SIZE, Image.LANCZOS)
+
+            buf = BytesIO()
+            result.save(
+                buf,
+                format="JPEG",
+                quality=self.IMAGE_JPEG_QUALITY,
+                optimize=True,
+            )
+
+        name = os.path.splitext(os.path.basename(self.image.name))[0] + ".jpg"
+        self.image.save(name, ContentFile(buf.getvalue()), save=False)
+
+    def save(self, *args, **kwargs):
+        is_new = self.pk is None
+        if is_new and self.image:
+            self._compress_image()
+        super().save(*args, **kwargs)
 
 
 class Tag(models.Model):

--- a/apps/blog/tests/test_models.py
+++ b/apps/blog/tests/test_models.py
@@ -1,9 +1,25 @@
-import pytest
-from django.db import IntegrityError
+from io import BytesIO
 
-from apps.blog.models import Comment, Post, PostVersion
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.db import IntegrityError
+from PIL import Image
+
+from apps.accounts.tests.factories import UserFactory
+from apps.blog.models import Comment, Post, PostImage, PostVersion
 
 from .factories import CommentFactory, PostFactory, PostVersionFactory
+
+
+def _make_test_image(width, height, fmt="JPEG", mode="RGB"):
+    buf = BytesIO()
+    img = Image.new(mode, (width, height), color="red")
+    img.save(buf, format=fmt)
+    buf.seek(0)
+    ext = {"JPEG": "jpg", "PNG": "png", "WEBP": "webp", "GIF": "gif"}[fmt]
+    return SimpleUploadedFile(
+        f"test.{ext}", buf.read(), content_type=f"image/{ext}"
+    )
 
 
 @pytest.mark.django_db
@@ -158,3 +174,70 @@ class TestPostVersionModel:
     def test_str_representation(self):
         version = PostVersionFactory(version_number=2)
         assert str(version) == f"{version.post} — v2"
+
+
+@pytest.mark.django_db
+class TestPostImageCompression:
+    def test_large_image_is_resized(self):
+        """Image larger than 1920x1080 is resized down."""
+        user = UserFactory()
+        post_image = PostImage(
+            image=_make_test_image(3000, 2000), uploaded_by=user
+        )
+        post_image.save()
+
+        img = Image.open(post_image.image)
+        assert img.size[0] <= 1920
+        assert img.size[1] <= 1080
+        assert img.format == "JPEG"
+
+    def test_small_image_not_upscaled(self):
+        """Image smaller than max size keeps its dimensions."""
+        user = UserFactory()
+        post_image = PostImage(
+            image=_make_test_image(800, 600), uploaded_by=user
+        )
+        post_image.save()
+
+        img = Image.open(post_image.image)
+        assert img.size == (800, 600)
+        assert img.format == "JPEG"
+
+    def test_png_converted_to_jpeg(self):
+        """PNG is converted to JPEG."""
+        user = UserFactory()
+        post_image = PostImage(
+            image=_make_test_image(500, 500, fmt="PNG"), uploaded_by=user
+        )
+        post_image.save()
+
+        img = Image.open(post_image.image)
+        assert img.format == "JPEG"
+        assert post_image.image.name.endswith(".jpg")
+
+    def test_png_with_transparency_converted(self):
+        """PNG with alpha channel is converted to JPEG with white background."""
+        user = UserFactory()
+        post_image = PostImage(
+            image=_make_test_image(500, 500, fmt="PNG", mode="RGBA"),
+            uploaded_by=user,
+        )
+        post_image.save()
+
+        img = Image.open(post_image.image)
+        assert img.format == "JPEG"
+        assert img.mode == "RGB"
+
+    def test_compressed_file_is_smaller(self):
+        """Compressed file should be significantly smaller than a large original."""
+        user = UserFactory()
+        original = _make_test_image(3000, 2000)
+        original_size = len(original.read())
+        original.seek(0)
+
+        post_image = PostImage(image=original, uploaded_by=user)
+        post_image.save()
+
+        post_image.image.seek(0, 2)
+        compressed_size = post_image.image.tell()
+        assert compressed_size < original_size


### PR DESCRIPTION
## Description

Closes #184

Ajoute la compression automatique des images uploadées dans les articles (`PostImage`) pour optimiser l'espace de stockage serveur.

---

## Documentation

### Ce qui a été implémenté
- **`apps/blog/models.py`** : Ajout de `_compress_image()` et override de `save()` sur `PostImage`
- **`apps/blog/tests/test_models.py`** : 5 tests unitaires de compression

### Choix techniques
- **Max 1920×1080** — résolution Full HD, bon compromis pour un blog
- **JPEG qualité 85 + optimize** — cohérent avec le pattern avatar existant
- **Compression à la création uniquement** — pas de retraitement au re-save
- **Gestion transparence** (RGBA/LA/P → RGB fond blanc) via même pattern que `Profile._compress_avatar()`

### Tests
- 205 tests passés, 98% de couverture
- 5 nouveaux tests : redimensionnement, non-upscale, conversion PNG→JPEG, transparence, taille réduite