### PR TITLE
feat: messages d'erreur précis pour l'upload de fichiers (#190)

### DIFF
--- a/apps/blog/tests/test_api.py
+++ b/apps/blog/tests/test_api.py
@@ -1022,6 +1022,7 @@ class TestPostVideoUploadAPI:
             API_UPLOAD_VIDEO_URL, {"video": fake_file}, format="multipart"
         )
         assert response.status_code == 400
+        assert "Format non autorisé" in response.data["video"][0]
 
     def test_upload_video_too_large(self):
         user = UserFactory()
@@ -1034,3 +1035,4 @@ class TestPostVideoUploadAPI:
             API_UPLOAD_VIDEO_URL, {"video": large_file}, format="multipart"
         )
         assert response.status_code == 400
+        assert "50 Mo" in response.data["video"][0]

--- a/docs/browser-test-checklist.md
+++ b/docs/browser-test-checklist.md
@@ -350,7 +350,8 @@
 - **Actions et vérifications** :
   - Upload d'un fichier vidéo MP4 valide (< 50 Mo) → la vidéo est insérée avec succès
   - Upload d'un fichier vidéo WebM valide → la vidéo est insérée avec succès
-  - Upload d'un fichier > 50 Mo → la vidéo n'est pas insérée ou un message d'erreur s'affiche
+  - Upload d'un fichier au format non autorisé (ex: .avi, .mov) → une notification d'erreur s'affiche avec le message précisant le format (ex: « Format non autorisé. Utilisez MP4, WebM ou OGG. »)
+  - Upload d'un fichier > 50 Mo → une notification d'erreur s'affiche avec le message précisant la taille (ex: « La taille de la vidéo ne doit pas dépasser 50 Mo. »)
   - Les formats MP4, WebM et OGG sont acceptés
 
 ---

--- a/frontend/src/components/blog/PostForm.jsx
+++ b/frontend/src/components/blog/PostForm.jsx
@@ -6,6 +6,7 @@ import { TagsInput } from "@mantine/core";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Helmet } from "react-helmet-async";
 import { Link, useBlocker, useNavigate, useParams } from "react-router-dom";
+import { notifications } from "@mantine/notifications";
 import { api } from "../../api/client";
 
 const VIDEO_TYPES = ["video/mp4", "video/webm", "video/ogg"];
@@ -20,7 +21,13 @@ async function uploadFile(file) {
     return res.data.url;
   }
   const fieldErrors = isVideo ? res.errors?.video : res.errors?.image;
-  throw new Error(fieldErrors?.[0] || res.errors?.detail || "Erreur lors de l'upload du fichier");
+  const errorMessage = fieldErrors?.[0] || res.errors?.detail || "Erreur lors de l'upload du fichier";
+  notifications.show({
+    title: "Erreur d'upload",
+    message: errorMessage,
+    color: "red",
+  });
+  throw new Error(errorMessage);
 }
 
 function BlockNoteEditor({ initialContent, editorRef, onChange }) {


### PR DESCRIPTION
## Description

Closes #190

Affiche une notification Mantine avec le message d'erreur spécifique du backend (format non autorisé, taille dépassée) lors de l'échec d'upload de fichier dans l'éditeur BlockNote, au lieu du message générique de BlockNote.

---

## Changements

- **`frontend/src/components/blog/PostForm.jsx`** : Import de `notifications` de `@mantine/notifications` et affichage d'une notification d'erreur avec le message spécifique du backend dans `uploadFile`.
- **`apps/blog/tests/test_api.py`** : Assertions sur le contenu des messages d'erreur pour les tests d'upload vidéo (format et taille).
- **`docs/browser-test-checklist.md`** : Mise à jour du scénario 4.16 avec les messages d'erreur précis attendus.

## Tests

- 211 tests passent (0 échecs)
- Tests spécifiques enrichis : `test_upload_video_invalid_type`, `test_upload_video_too_large`