### PR TITLE
fix: corriger le positionnement image couverture liste article

### DIFF
--- a/docs/browser-test-checklist.md
+++ b/docs/browser-test-checklist.md
@@ -140,6 +140,7 @@
   - Les articles publiés sont affichés sous forme de cartes
   - Maximum 10 articles affichés
   - Chaque carte affiche : titre, auteur (nom + avatar), date, extrait du contenu, les tags de l'article (s'il en a), et l'image de couverture en miniature (si définie)
+  - L'image de couverture est correctement alignée avec le contenu de la carte (pas de décalage horizontal)
   - Les tags sont affichés en dessous du titre de chaque carte
   - Un lien "Voir tous les articles" est présent si plus de 10 articles existent
 

--- a/frontend/src/components/blog/PostCard.jsx
+++ b/frontend/src/components/blog/PostCard.jsx
@@ -21,8 +21,7 @@ export default function PostCard({ post }) {
           <img
             src={post.cover_image}
             alt={post.title}
-            className="w-full h-48 object-cover rounded-t-lg -mt-6 -mx-6 mb-4"
-            style={{ width: "calc(100% + 3rem)" }}
+            className="w-full h-48 object-cover rounded-t-lg -mt-6 mb-4"
           />
         </Link>
       )}


### PR DESCRIPTION
## Description

Closes #194

L'image de couverture dans la liste des articles était décalée à gauche à cause de marges négatives (`-mx-6`) et d'un `width: calc(100% + 3rem)` appliqués alors que le conteneur `.card` n'a pas de padding horizontal.

---

## Changements

- **`PostCard.jsx`** : suppression de `-mx-6` et du style inline `width: calc(100% + 3rem)` sur l'image de couverture
- **`docs/browser-test-checklist.md`** : ajout d'une vérification d'alignement de l'image dans le scénario 3.1

## Comment vérifier

Ouvrir la page d'accueil (`/`) ou la liste des articles (`/articles`) avec un article ayant une image de couverture — l'image doit être alignée avec le reste du contenu de la carte.