### PR TITLE
chore(skills): quick wins — fix bugs, dedup, add lint

### DIFF
--- a/.claude/skills/_shared/browser-tests/environment.md
+++ b/.claude/skills/_shared/browser-tests/environment.md
@@ -1,0 +1,54 @@
+# Préparation de l'environnement — tests browser
+
+Partagé entre `regression-tests` et `browser-tests-on-demand`.
+
+## Variables d'environnement attendues
+
+| Variable | Description | Défaut |
+|----------|-------------|--------|
+| `BASE_URL` | URL frontend (nginx) de l'environnement testé | `https://blog.nickorp.com` (`regression-tests`) / injecté par le workflow (`browser-tests-on-demand`) |
+| `API_URL` | URL API de l'environnement testé | idem |
+
+Les deux skills construisent toutes leurs URLs à partir de `BASE_URL` (ex :
+`${BASE_URL}/comptes/connexion`).
+
+## Healthcheck initial
+
+Avant de lancer les scénarios, vérifier que l'environnement est joignable :
+
+```bash
+# Sans sandbox : requis dans claude-worker (root dans container)
+export AGENT_BROWSER_ARGS=--no-sandbox
+
+agent-browser open "$BASE_URL" \
+  && agent-browser wait --load networkidle \
+  && agent-browser snapshot -i
+```
+
+**Si l'environnement n'est pas joignable** :
+
+- `regression-tests` → afficher un message d'erreur et **STOP**.
+- `browser-tests-on-demand` → marquer tous les scénarios `SKIP` (raison :
+  "env non joignable"), compiler le rapport habituel, terminer avec code 0
+  (le workflow appelant détruira l'env via `if: always()`).
+
+## Distinguer erreur infra vs erreur test
+
+Si le healthcheck échoue, **ne pas** noter les scénarios `FAIL` — la cause
+est infrastructurelle, pas fonctionnelle. Utiliser `SKIP` + détail, pour
+qu'un FAIL massif ne maquille pas un bug réseau.
+
+## Durée de vie de l'environnement
+
+L'environnement Docker éphémère est géré par le **workflow GitHub Actions
+appelant** (`regression-tests.yml` ou `browser-tests.yml`). Le skill ne
+touche **jamais** à `tnr-docker.sh`.
+
+## Nettoyage final
+
+```bash
+agent-browser close --all
+```
+
+Le workflow appelant s'occupe du `docker network disconnect` et du
+`tnr-docker.sh down` dans une étape `if: always()`.

--- a/.claude/skills/_shared/browser-tests/execution.md
+++ b/.claude/skills/_shared/browser-tests/execution.md
@@ -1,0 +1,76 @@
+# Exécution d'un scénario de test browser
+
+Partagé entre `regression-tests` et `browser-tests-on-demand`.
+
+## Pattern d'exécution
+
+Pour chaque scénario :
+
+1. **Identifier le type** (`[PUBLIC]` / `[AUTH]` / `[OWNER]`) → choisir la
+   session (voir `sessions.md`).
+2. **Suivre les étapes** décrites dans le scénario via `agent-browser`
+   (`open`, `snapshot`, `click`, `fill`, `wait`, `get text`, `get url`).
+3. **Vérifier chaque assertion** (présence d'éléments, texte attendu,
+   navigation correcte).
+4. **En cas d'échec** : capturer un screenshot et enregistrer le détail.
+5. **Enregistrer le résultat** : `PASS` / `FAIL` / `SKIP` avec détail.
+
+```bash
+# Navigation
+agent-browser --session "$SESSION" open "$URL"
+agent-browser --session "$SESSION" wait --load networkidle
+
+# Découverte des refs
+agent-browser --session "$SESSION" snapshot -i
+
+# Actions (exemple)
+agent-browser --session "$SESSION" fill @eN "valeur"
+agent-browser --session "$SESSION" click @eM
+
+# Vérification
+agent-browser --session "$SESSION" snapshot -i
+agent-browser --session "$SESSION" get text @eX
+agent-browser --session "$SESSION" get url
+
+# En cas d'échec, screenshot obligatoire
+agent-browser --session "$SESSION" screenshot /tmp/browser-fail-${TEST_ID}.png
+```
+
+## Évaluation du résultat
+
+| Statut | Critère |
+|--------|---------|
+| `PASS` | Comportement observé == résultat attendu du cahier |
+| `FAIL` | Comportement observé != résultat attendu |
+| `SKIP` | Prérequis manquant, donnée absente, ou ID inconnu dans le checklist |
+
+## Règles de robustesse
+
+1. **Ne jamais s'arrêter sur un échec** — continuer avec les tests suivants.
+2. **Capturer un screenshot** pour chaque `FAIL`.
+3. **Timeout** : si un test bloque plus de 30 secondes, le marquer `SKIP`
+   avec détail `"Timeout"`.
+4. **Tests `[OWNER]`** : si les données de test (articles, commentaires) ne
+   sont pas présentes, les créer en début de session plutôt que de `SKIP`.
+5. **Refs dynamiques** : re-snapshotter après chaque navigation ou changement
+   DOM — les refs `@eN` changent.
+
+## Structure du résultat à conserver
+
+Pour chaque test exécuté, conserver en mémoire :
+
+```json
+{
+  "id": "1.1",
+  "section": "Navigation et Layout",
+  "title": "Affichage du header",
+  "type": "PUBLIC",
+  "status": "PASS",
+  "details": "",
+  "screenshot": "",
+  "url": "https://..."
+}
+```
+
+Les skills consommateurs (`regression-tests`, `browser-tests-on-demand`)
+agrègent ces résultats pour produire leur rapport et leurs issues GitHub.

--- a/.claude/skills/_shared/browser-tests/sessions.md
+++ b/.claude/skills/_shared/browser-tests/sessions.md
@@ -1,0 +1,45 @@
+# Gestion des sessions d'authentification — tests browser
+
+Partagé entre `regression-tests` et `browser-tests-on-demand`.
+
+## Sessions nommées
+
+Les tests utilisent des sessions `agent-browser` nommées pour éviter de se
+reconnecter à chaque test et pour isoler les contextes d'auth :
+
+| Session | Usage | Identifiant | Mot de passe |
+|---------|-------|-------------|--------------|
+| `public` | Tests `[PUBLIC]` (non connecté) | — | — |
+| `user1` | Tests `[AUTH]` et `[OWNER]` | `testuser@example.com` | `Testpass123!` |
+| `user2` | Tests inter-utilisateurs | `testuser2@example.com` | `Testpass123!` |
+
+## Connexion d'une session authentifiée
+
+Les refs `@e1`, `@e2`, … retournés par `snapshot -i` sont **dynamiques**. Il
+faut snapshotter puis utiliser les refs réels (pas de placeholders type
+`@emailInput`).
+
+```bash
+# Dans claude-worker, Chrome doit démarrer sans sandbox
+export AGENT_BROWSER_ARGS=--no-sandbox
+
+agent-browser --session user1 open "$BASE_URL/comptes/connexion"
+agent-browser --session user1 wait --load networkidle
+agent-browser --session user1 snapshot -i
+# Lire les refs retournés dans la sortie (ex: @e1 = email, @e2 = password, @e3 = submit)
+agent-browser --session user1 fill @e1 "testuser@example.com"
+agent-browser --session user1 fill @e2 "Testpass123!"
+agent-browser --session user1 click @e3
+agent-browser --session user1 wait --load networkidle
+```
+
+## Règles d'utilisation
+
+1. **Réutiliser** les sessions entre tests du même type (pas de reconnexion par
+   test).
+2. **Choisir** la session à partir du type déclaré du scénario (`[PUBLIC]` /
+   `[AUTH]` / `[OWNER]`).
+3. **Ne jamais** mélanger les sessions dans un même scénario — un test
+   `[OWNER]` peut toutefois utiliser `user1` + `user2` quand il teste
+   l'interaction inter-utilisateur (explicitement prévu dans le scénario).
+4. **Nettoyage final** : `agent-browser close --all` à la fin du run.

--- a/.claude/skills/browser-tests-on-demand/SKILL.md
+++ b/.claude/skills/browser-tests-on-demand/SKILL.md
@@ -99,21 +99,9 @@ Pour chaque ID retenu, lis la définition complète du scénario depuis
 
 ## PHASE 2 — Préparation de l'environnement
 
-L'environnement Docker éphémère est déjà démarré par le workflow appelant.
-Vérifie qu'il est joignable avant de lancer les tests :
-
-```bash
-# Forcer Chrome à démarrer sans sandbox dans claude-worker
-export AGENT_BROWSER_ARGS=--no-sandbox
-
-agent-browser open "$BASE_URL"
-agent-browser wait --load networkidle
-agent-browser snapshot -i
-```
-
-> **Si l'env n'est pas joignable** : marque tous les scénarios SKIP,
-> compile un rapport d'erreur et termine. Le workflow appelant détruira
-> l'env de toute façon (`if: always()`).
+Lis la référence partagée `.claude/skills/_shared/browser-tests/environment.md`
+et applique le healthcheck initial. Si l'environnement n'est pas joignable,
+marque tous les scénarios `SKIP` et passe à la compilation du rapport.
 
 ---
 
@@ -121,47 +109,15 @@ agent-browser snapshot -i
 
 ### 3.1 Gestion des sessions d'authentification
 
-Utilise des sessions nommées selon le type de test :
-
-- `--session public` pour les tests `[PUBLIC]`
-- `--session user1` pour les tests `[AUTH]` (`testuser@example.com` / `Testpass123!`)
-- `--session user2` pour les tests `[OWNER]` nécessitant un deuxième utilisateur
-
-Si une session authentifiée n'existe pas encore, connecte-toi d'abord.
-**Important** : les refs `@e1`, `@e2`… retournés par `snapshot -i` sont
-dynamiques — il faut snapshotter puis utiliser les refs réels (pas de
-placeholders type `@emailInput`).
-
-```bash
-agent-browser --session user1 open "$BASE_URL/comptes/connexion"
-agent-browser --session user1 wait --load networkidle
-agent-browser --session user1 snapshot -i
-# Lis les refs retournés (ex: @e1 = email, @e2 = password, @e3 = bouton submit)
-agent-browser --session user1 fill @e1 "testuser@example.com"
-agent-browser --session user1 fill @e2 "Testpass123!"
-agent-browser --session user1 click @e3
-agent-browser --session user1 wait --load networkidle
-```
+Lis la référence partagée `.claude/skills/_shared/browser-tests/sessions.md`
+pour les conventions de sessions (`public` / `user1` / `user2`) et la
+procédure de connexion avec refs dynamiques.
 
 ### 3.2 Exécution d'un scénario
 
-Pour chaque test à exécuter :
-
-1. **Identifie le type** (`[PUBLIC]` / `[AUTH]` / `[OWNER]`) → choisis la session
-2. **Suis les étapes** décrites dans le scénario via `agent-browser`
-   (open, snapshot, click, fill, wait, get text, etc.)
-3. **Vérifie chaque assertion** (présence d'éléments, texte attendu, navigation correcte)
-4. **En cas d'échec** : capture un screenshot et enregistre le détail
-5. **Enregistre le résultat** : `PASS` / `FAIL` (avec détail) / `SKIP` (avec raison)
-
-```bash
-# Exemple générique
-agent-browser --session user1 open "$BASE_URL/page-cible"
-agent-browser --session user1 wait --load networkidle
-agent-browser --session user1 snapshot -i
-# Vérifications via agent-browser get text / get url / etc.
-agent-browser --session user1 screenshot --full  # En cas d'échec, pour preuve
-```
+Lis la référence partagée `.claude/skills/_shared/browser-tests/execution.md`
+pour le pattern d'exécution, les règles d'évaluation (PASS/FAIL/SKIP), la
+capture de screenshots et la structure du résultat à conserver.
 
 ---
 
@@ -219,47 +175,50 @@ Construis le corps de l'issue avec :
 - Section détaillée pour chaque FAIL
 - Lien vers le run GitHub Actions
 
-Puis crée l'issue avec le label `non-regression tests` :
+Puis crée l'issue avec le label `non-regression tests`.
+
+> **Important :** `gh issue create` ne supporte **pas** `--json` ; il sort
+> l'URL de l'issue créée sur stdout. On extrait le numéro de l'URL.
 
 ```bash
-TRACKING_ISSUE=$(gh issue create \
+# Écris d'abord le corps dans un fichier temporaire pour éviter les pièges
+# de quoting multi-niveau (backticks, $, guillemets imbriqués).
+BODY_FILE=$(mktemp)
+{
+  echo "## 🧪 Tests browser on-demand"
+  echo ""
+  echo "**Date :** $(date -u '+%Y-%m-%d %H:%M UTC')"
+  echo "**Branche testée :** \`$BRANCH\`"
+  echo "**Filtre :** \`$TEST_FILTER\`"
+  echo "**Statut :** $STATUS_EMOJI $STATUS_TEXT"
+  [ -n "$LINKED_ISSUE" ] && echo "**Issue liée :** #$LINKED_ISSUE"
+  echo "**Run GitHub Actions :** $RUN_URL"
+  echo ""
+  echo "---"
+  echo ""
+  echo "### Résultats ($PASS_COUNT ✅ / $FAIL_COUNT ❌ / $SKIP_COUNT ⏭️ sur $TOTAL)"
+  echo ""
+  echo "| ID | Scénario | Type | Résultat |"
+  echo "|----|----------|------|----------|"
+  # [une ligne par test, emoji selon status]
+  # [Si FAIL_COUNT > 0 : section "Détail des échecs" avec un bloc par FAIL]
+} > "$BODY_FILE"
+
+ISSUE_URL=$(gh issue create \
   --repo nicolasdeclerck/test-squad-automation \
   --title "Tests browser on-demand — $(date -u '+%Y-%m-%d %H:%M') — ${STATUS_EMOJI}" \
   --label "non-regression tests" \
-  --body "## 🧪 Tests browser on-demand
+  --body-file "$BODY_FILE")
 
-**Date :** $(date -u '+%Y-%m-%d %H:%M UTC')
-**Branche testée :** \`$BRANCH\`
-**Filtre :** \`$TEST_FILTER\`
-**Statut :** $STATUS_EMOJI $STATUS_TEXT
-$([ -n \"\$LINKED_ISSUE\" ] && echo \"**Issue liée :** #\$LINKED_ISSUE\")
-**Run GitHub Actions :** $RUN_URL
+TRACKING_ISSUE=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
 
----
-
-### Résultats ($PASS_COUNT ✅ / $FAIL_COUNT ❌ / $SKIP_COUNT ⏭️ sur $TOTAL)
-
-| ID | Scénario | Type | Résultat |
-|----|----------|------|----------|
-[une ligne par test, emoji selon status]
-
-[Si FAIL_COUNT > 0 :]
----
-
-### Détail des échecs
-
-#### [TEST_ID] — [titre du test]
-- **Type :** [PUBLIC/AUTH/OWNER]
-- **URL testée :** [url]
-- **Comportement observé :** [détail]
-- **Comportement attendu :** [extrait du cahier]
-- **Screenshot :** \`[chemin]\`
-
-[... pour chaque FAIL ...]
-" \
-  --json number --jq '.number')
+if [ -z "$TRACKING_ISSUE" ]; then
+  echo "❌ Impossible d'extraire le numéro d'issue depuis : $ISSUE_URL"
+  exit 1
+fi
 
 echo "Issue de suivi créée : #$TRACKING_ISSUE"
+rm -f "$BODY_FILE"
 ```
 
 #### 4.2.3 Fermeture de l'issue si tout passe

--- a/.claude/skills/regression-tests/SKILL.md
+++ b/.claude/skills/regression-tests/SKILL.md
@@ -59,13 +59,9 @@ Redis, Celery — mais sans Traefik ni certificat TLS.
 
 ### 1.3 Vérification de l'environnement
 
-Vérifie que l'application est accessible :
-
-```bash
-agent-browser open ${BASE_URL} && agent-browser wait --load networkidle && agent-browser snapshot -i
-```
-
-Si l'application n'est pas accessible, affiche un message d'erreur et **STOP**.
+Lis la référence partagée `.claude/skills/_shared/browser-tests/environment.md`
+et applique le healthcheck. Pour `regression-tests`, si l'environnement n'est
+pas joignable : afficher un message d'erreur et **STOP**.
 
 ### 1.4 Initialisation du rapport
 
@@ -130,62 +126,23 @@ Pour chaque test :
 
 ### 2.2 Gestion de l'authentification
 
-Utilise des sessions nommées pour gérer les contextes d'auth :
-
-```bash
-# Session non connectée (tests [PUBLIC])
-agent-browser --session public open ${BASE_URL}
-
-# Connexion utilisateur 1 (tests [AUTH] et [OWNER])
-agent-browser --session user1 open ${BASE_URL}/comptes/connexion
-agent-browser --session user1 snapshot -i
-agent-browser --session user1 fill @eN "testuser@example.com"
-agent-browser --session user1 fill @eM "Testpass123!"
-agent-browser --session user1 click @eK
-agent-browser --session user1 wait --load networkidle
-
-# Connexion utilisateur 2 (tests inter-utilisateurs)
-agent-browser --session user2 open ${BASE_URL}/comptes/connexion
-# ... même flow avec testuser2@example.com ...
-```
-
-**Important :** Réutilise les sessions entre les tests du même type pour
-éviter de se reconnecter à chaque test.
+Lis la référence partagée `.claude/skills/_shared/browser-tests/sessions.md`
+pour les conventions de sessions (`public` / `user1` / `user2`) et le flow
+de connexion avec refs dynamiques.
 
 ### 2.3 Exécution d'un test unitaire
 
-Pour chaque scénario, le pattern est :
-
-```bash
-# 1. Navigation
-agent-browser --session {session} open {url}
-agent-browser --session {session} wait --load networkidle
-
-# 2. Snapshot pour découvrir les éléments
-agent-browser --session {session} snapshot -i
-
-# 3. Actions (fill, click, select selon le scénario)
-agent-browser --session {session} fill @eN "valeur"
-agent-browser --session {session} click @eM
-
-# 4. Vérification
-agent-browser --session {session} snapshot -i
-agent-browser --session {session} get text @eX
-agent-browser --session {session} get url
-```
+Lis la référence partagée `.claude/skills/_shared/browser-tests/execution.md`
+pour le pattern d'exécution complet.
 
 ### 2.4 Évaluation du résultat
 
-Pour chaque vérification décrite dans le cahier :
+Les règles `PASS` / `FAIL` / `SKIP` sont décrites dans
+`.claude/skills/_shared/browser-tests/execution.md`. Pour la TNR :
 
-- **PASS** : le comportement observé correspond au résultat attendu
-- **FAIL** : le comportement observé diffère du résultat attendu
-- **SKIP** : le test ne peut pas être exécuté (prérequis manquant, donnée de test absente)
-
-En cas de **FAIL**, capture systématiquement :
-```bash
-agent-browser --session {session} screenshot /tmp/regression-fail-{test_id}.png
-```
+- En cas de `FAIL`, nomme le screenshot `/tmp/regression-fail-{test_id}.png`
+  (convention spécifique au skill `regression-tests` pour suivi des runs
+  nightly).
 
 ### 2.5 Enregistrement du résultat
 

--- a/.claude/skills/ticket-workflow/SKILL.md
+++ b/.claude/skills/ticket-workflow/SKILL.md
@@ -95,7 +95,7 @@ else
     || echo "Worktree déjà existant, réutilisation"
 fi
 
-cd "$WORKTREE_PATH"
+cd "$WORKTREE_PATH" || { echo "❌ Worktree introuvable: $WORKTREE_PATH"; exit 1; }
 ```
 
 **Critère de sortie :** `git worktree list` affiche `$WORKTREE_PATH`.

--- a/.claude/skills/ticket-workflow/references/phase-4-review.md
+++ b/.claude/skills/ticket-workflow/references/phase-4-review.md
@@ -141,6 +141,6 @@ gh pr review "$PR_NUMBER" --request-changes \
 ## 4.3 Nettoyage
 
 ```bash
-cd /workspace/test-squad-automation
+cd /workspace/test-squad-automation || exit 1
 git worktree remove "$REVIEW_WORKTREE" --force 2>/dev/null || true
 ```

--- a/.claude/skills/ticket-workflow/references/state-management.md
+++ b/.claude/skills/ticket-workflow/references/state-management.md
@@ -27,38 +27,73 @@ fi
 
 ## Fonction d'écriture d'état
 
-À réutiliser après chaque transition de phase :
+À réutiliser après chaque transition de phase.
+
+> **Important :** les variables sont passées à Python **par l'environnement**
+> (pas par interpolation shell dans le code Python). Cela évite qu'un
+> caractère spécial (`'`, `"`, `\`, saut de ligne, `$`) dans `BRANCH_NAME`,
+> `PR_NUMBER` ou une valeur numérique vide corrompe le JSON généré.
 
 ```bash
 write_state() {
-  python3 -c "
-import json, sys
-# Preserve browser_tests from existing state if present
+  NEW_PHASE="$1" \
+  ISSUE_NUMBER="${ISSUE_NUMBER}" \
+  STATE_FILE_PATH="$STATE_FILE" \
+  N_DEV="${N_DEV:-0}" \
+  N_REVIEW="${N_REVIEW:-0}" \
+  N_CORRECTIONS="${N_CORRECTIONS:-0}" \
+  N_BROWSER_TEST="${N_BROWSER_TEST:-0}" \
+  CURRENT_TASK="${CURRENT_TASK:-0}" \
+  APPROVED="${APPROVED:-False}" \
+  BRANCH_NAME="${BRANCH_NAME:-}" \
+  PR_NUMBER="${PR_NUMBER:-}" \
+  python3 - <<'PY' > "$STATE_FILE.tmp" && mv "$STATE_FILE.tmp" "$STATE_FILE"
+import json, os
+
+state_file = os.environ["STATE_FILE_PATH"]
+
+# Preserve browser_tests and tasks from existing state if present
 existing = {}
 try:
-    with open('$STATE_FILE') as f:
+    with open(state_file) as f:
         existing = json.load(f)
-except:
+except (FileNotFoundError, json.JSONDecodeError):
     pass
 
+def as_int(name, default=0):
+    v = os.environ.get(name, "").strip()
+    return int(v) if v else default
+
+def as_bool(name, default=False):
+    v = os.environ.get(name, "").strip().lower()
+    if v in ("true", "1", "yes"):
+        return True
+    if v in ("false", "0", "no", ""):
+        return False
+    return default
+
 state = {
-  'issue_number': {ISSUE_NUMBER},
-  'phase': '$1',
-  'n_dev': $N_DEV,
-  'n_review': $N_REVIEW,
-  'n_corrections': $N_CORRECTIONS,
-  'n_browser_test': ${N_BROWSER_TEST:-0},
-  'current_task': $CURRENT_TASK,
-  'approved': $APPROVED,
-  'branch': '${BRANCH_NAME:-}',
-  'pr_number': '${PR_NUMBER:-}',
-  'browser_tests': existing.get('browser_tests', []),
-  'tasks': existing.get('tasks', [])
+    "issue_number": as_int("ISSUE_NUMBER"),
+    "phase": os.environ["NEW_PHASE"],
+    "n_dev": as_int("N_DEV"),
+    "n_review": as_int("N_REVIEW"),
+    "n_corrections": as_int("N_CORRECTIONS"),
+    "n_browser_test": as_int("N_BROWSER_TEST"),
+    "current_task": as_int("CURRENT_TASK"),
+    "approved": as_bool("APPROVED"),
+    "branch": os.environ.get("BRANCH_NAME", ""),
+    "pr_number": os.environ.get("PR_NUMBER", ""),
+    "browser_tests": existing.get("browser_tests", []),
+    "tasks": existing.get("tasks", []),
 }
-print(json.dumps(state, indent=2))
-" > "$STATE_FILE"
+print(json.dumps(state, indent=2, ensure_ascii=False))
+PY
 }
 ```
+
+L'écriture passe par un fichier temporaire (`$STATE_FILE.tmp` + `mv`) pour
+rendre le remplacement atomique : si Python échoue, le fichier d'état
+précédent reste intact et la reprise fonctionne.
 
 ## Structure de `.claude-state.json`
 
@@ -91,7 +126,14 @@ print(json.dumps(state, indent=2))
 }
 ```
 
-Phases possibles : `"1"`, `"2"`, `"3"`, `"4"`, `"5"`, `"6"`, `"7"`, `"done"`
+Phases possibles : `"1"`, `"2"`, `"3"`, `"4"`, `"5"`, `"done"`
+
+> **Note :** Les phases `"6"` (tests browser) et `"7"` (corrections post-tests
+> browser) ont été retirées du `ticket-workflow` lors du découplage. Les tests
+> browser sont désormais exécutés à la demande via le workflow GitHub Actions
+> `browser-tests.yml` (skill séparé `browser-tests-on-demand`). Si un state
+> file existant contient `phase: "6"` ou `"7"`, il faut le considérer comme
+> `"done"` (tests browser déportés).
 
 ## Gestion des erreurs — Interruption par quota de tokens
 

--- a/.github/workflows/lint-skills.yml
+++ b/.github/workflows/lint-skills.yml
@@ -1,0 +1,29 @@
+name: Lint Skills
+
+on:
+  pull_request:
+    paths:
+      - '.claude/skills/**'
+      - 'scripts/lint-skills.py'
+      - '.github/workflows/lint-skills.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - '.claude/skills/**'
+      - 'scripts/lint-skills.py'
+
+permissions:
+  contents: read
+
+jobs:
+  lint-skills:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+
+      - name: Lint bash blocks in SKILL.md files
+        run: python3 scripts/lint-skills.py

--- a/scripts/lint-skills.py
+++ b/scripts/lint-skills.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Lint bash code blocks embedded in SKILL.md / references.
+
+Extracts fenced ```bash blocks from every Markdown file under
+``.claude/skills/``, writes each block to a temporary file, and runs
+``shellcheck`` on it. Exits non-zero if any block fails.
+
+Notes
+-----
+- SKILL.md snippets mix shell variables (``$VAR``) and placeholder
+  syntax (``{ISSUE_NUMBER}``, ``{session}``). To avoid a flood of
+  false-positives, we run shellcheck with ``-e SC1009,SC1072,SC1073,SC2086``
+  and ``-S warning`` (errors + warnings only, no info/style).
+- ``{PLACEHOLDER}`` tokens are substituted with ``PLACEHOLDER`` before
+  lint so shellcheck can parse the block as valid bash.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+SKILLS_DIR = ROOT / ".claude" / "skills"
+
+# Directories under .claude/skills/ that should NOT be linted:
+# - _archived: historical snapshots, not maintained
+# - agent-browser: external skill imported as-is, not our code
+EXCLUDED_DIRS = {"_archived", "agent-browser"}
+
+FENCE_RE = re.compile(r"^```bash\s*$")
+FENCE_END_RE = re.compile(r"^```\s*$")
+PLACEHOLDER_RE = re.compile(r"\{([A-Z_][A-Z0-9_]*)\}")
+
+SHELLCHECK_DISABLED = [
+    "SC1009",  # confused about mismatched keywords in heredoc
+    "SC1072",
+    "SC1073",
+    "SC2016",  # single quotes around $VAR in Python heredocs is intentional
+    "SC2086",  # quoting of $VAR — many snippets rely on word splitting
+    "SC2154",  # referenced but not assigned (env vars injected by workflow)
+    "SC2155",  # declare and assign separately
+    "SC2034",  # unused variables (they are used later in the surrounding prose)
+]
+
+
+def extract_bash_blocks(path: pathlib.Path) -> list[tuple[int, str]]:
+    """Return list of (start_line, block_content) for each ```bash block."""
+    blocks: list[tuple[int, str]] = []
+    lines = path.read_text(encoding="utf-8").splitlines()
+    i = 0
+    while i < len(lines):
+        if FENCE_RE.match(lines[i]):
+            start = i + 1
+            buf: list[str] = []
+            i += 1
+            while i < len(lines) and not FENCE_END_RE.match(lines[i]):
+                buf.append(lines[i])
+                i += 1
+            blocks.append((start, "\n".join(buf) + "\n"))
+        i += 1
+    return blocks
+
+
+def normalise(block: str) -> str:
+    """Replace ``{PLACEHOLDER}`` tokens with ``PLACEHOLDER`` so shellcheck parses."""
+    return PLACEHOLDER_RE.sub(lambda m: m.group(1), block)
+
+
+def lint_block(block: str) -> tuple[int, str]:
+    disabled = ",".join(SHELLCHECK_DISABLED)
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".sh", delete=False, encoding="utf-8"
+    ) as f:
+        f.write("#!/usr/bin/env bash\n")
+        f.write(normalise(block))
+        tmp = f.name
+    try:
+        proc = subprocess.run(
+            [
+                "shellcheck",
+                "--shell=bash",
+                "-S",
+                "warning",
+                "-e",
+                disabled,
+                tmp,
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return proc.returncode, proc.stdout + proc.stderr
+    finally:
+        pathlib.Path(tmp).unlink(missing_ok=True)
+
+
+def main() -> int:
+    if not SKILLS_DIR.exists():
+        print(f"No skills directory at {SKILLS_DIR}", file=sys.stderr)
+        return 0
+
+    md_files = sorted(
+        p
+        for p in SKILLS_DIR.rglob("*.md")
+        if not any(part in EXCLUDED_DIRS for part in p.relative_to(SKILLS_DIR).parts)
+    )
+    failed = 0
+    total = 0
+
+    for md in md_files:
+        rel = md.relative_to(ROOT)
+        blocks = extract_bash_blocks(md)
+        for start_line, block in blocks:
+            total += 1
+            rc, output = lint_block(block)
+            if rc != 0:
+                failed += 1
+                print(f"::error file={rel},line={start_line}::shellcheck failed")
+                print(f"--- {rel}:{start_line} ---")
+                print(output.rstrip())
+                print()
+
+    print(
+        f"lint-skills: {total - failed}/{total} bash blocks clean "
+        f"({failed} failing) across {len(md_files)} files."
+    )
+    return 1 if failed > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
- browser-tests-on-demand: remplace `gh issue create --json` (non supporté)
  par extraction du numéro depuis l'URL retournée, et passe le body via
  `--body-file` pour éviter les pièges de quoting multi-niveau.
- ticket-workflow/state-management: retire les phases 6/7 obsolètes (tests
  browser déportés dans browser-tests-on-demand) et robustifie `write_state()`
  en passant les variables par l'environnement + écriture atomique via
  fichier temporaire, pour éviter les `.claude-state.json` corrompus.
- Déduplication regression-tests / browser-tests-on-demand via un nouveau
  dossier `_shared/browser-tests/` (sessions, execution, environment).
- Nouveau workflow GitHub Actions `lint-skills.yml` + script
  `scripts/lint-skills.py` qui extrait les blocs ```bash des SKILL.md et
  les passe à shellcheck (warnings + errors, placeholders `{VAR}` remplacés).
- Corrige au passage deux warnings SC2164 (`cd "$WORKTREE_PATH"` et
  `cd /workspace/...`) dans ticket-workflow.