### PR TITLE
Add reading time estimation and primary topic display

### DIFF
--- a/apps/blog/serializers.py
+++ b/apps/blog/serializers.py
@@ -47,6 +47,7 @@ class PostListSerializer(serializers.ModelSerializer):
     author = AuthorSerializer(read_only=True)
     tags = TagSerializer(many=True, read_only=True)
     plain_content = serializers.SerializerMethodField()
+    reading_time_minutes = serializers.SerializerMethodField()
     has_draft = serializers.SerializerMethodField()
     cover_image = serializers.ImageField(read_only=True)
 
@@ -61,10 +62,21 @@ class PostListSerializer(serializers.ModelSerializer):
             "tags",
             "cover_image",
             "plain_content",
+            "reading_time_minutes",
             "has_draft",
             "published_at",
             "created_at",
         )
+
+    def get_reading_time_minutes(self, obj):
+        """Estime le temps de lecture (en minutes) affiché sur la liste."""
+        text = obj.content or ""
+        word_count = len(text.split())
+        # On ajuste la vitesse selon la densité (caractères par mot)
+        # pour les contenus techniques avec des mots longs.
+        avg_word_length = len(text) / word_count
+        wpm = 200 if avg_word_length < 7 else 150
+        return max(1, round(word_count / wpm))
 
     def get_has_draft(self, obj):
         request = self.context.get("request")

--- a/frontend/src/components/blog/PostDetail.jsx
+++ b/frontend/src/components/blog/PostDetail.jsx
@@ -124,17 +124,23 @@ export default function PostDetail() {
       ? post.draft_content
       : post.content;
 
+  // Sujet principal (utilisé pour le fil d'Ariane et le partage social).
+  const primaryTopic = post.tags[0].name.toUpperCase();
+
   return (
     <div className="max-w-6xl mx-auto px-4 py-12">
       <Helmet>
         <title>{displayTitle}</title>
-        <meta name="description" content={displayTitle} />
+        <meta name="description" content={`${primaryTopic} — ${displayTitle}`} />
       </Helmet>
 
       <div className="flex flex-col lg:flex-row lg:gap-8">
         {/* Article — colonne gauche */}
         <div className="flex-1 min-w-0">
           <article>
+            <p className="text-xs uppercase tracking-wide text-gray-500 mb-1">
+              {primaryTopic}
+            </p>
             <h1 className="text-3xl font-bold text-gray-900 mb-2">{displayTitle}</h1>
             {post.tags && post.tags.length > 0 && (
               <div className="flex flex-wrap gap-1 mb-4">


### PR DESCRIPTION
## Summary
This PR enhances the blog post presentation by adding reading time estimation to the API serializer and displaying the primary topic (first tag) prominently in the post detail view.

## Key Changes

- **Backend (PostListSerializer)**
  - Added `reading_time_minutes` field to estimate post reading time
  - Implements adaptive word-per-minute calculation (200 WPM for simple content, 150 WPM for technical content with longer words)
  - Returns minimum of 1 minute to avoid showing 0 minutes for very short posts
  - Included in serializer output fields

- **Frontend (PostDetail component)**
  - Extracted primary topic from the first tag for consistent use across the page
  - Added primary topic display above the post title as a small uppercase label
  - Enhanced meta description to include primary topic for better SEO (`"TOPIC — Title"` format)

## Implementation Details

The reading time calculation adjusts based on average word length to better handle technical content where longer words naturally reduce reading speed. The frontend uses the primary topic as a breadcrumb-like indicator and improves social sharing metadata by including the topic context in the description.

https://claude.ai/code/session_01WRh5RVWuV9Rphdt22YGRPT