### PR TITLE
claude/fix-environment-connectivity-Tgwh6

### DIFF
--- a/.claude/skills/_shared/browser-tests/environment.md
+++ b/.claude/skills/_shared/browser-tests/environment.md
@@ -14,7 +14,28 @@ Les deux skills construisent toutes leurs URLs à partir de `BASE_URL` (ex :
 
 ## Healthcheck initial
 
-Avant de lancer les scénarios, vérifier que l'environnement est joignable :
+Avant de lancer les scénarios, vérifier que l'environnement est joignable.
+
+**Préflight HTTP (rapide, diagnostique)** — boucle de retry avant de lancer
+le navigateur, pour absorber les races de démarrage (env juste remonté,
+réseau Docker juste attaché) :
+
+```bash
+# Retry curl jusqu'à ce que BASE_URL réponde 2xx/3xx (12 tentatives, 10s).
+for i in $(seq 1 12); do
+  if curl -sSf --max-time 10 -o /dev/null "$BASE_URL/"; then
+    echo "Env reachable (attempt $i)."
+    break
+  fi
+  echo "Preflight attempt $i/12 failed, retrying in 10s..."
+  sleep 10
+  if [ "$i" = "12" ]; then
+    echo "ERROR: env non joignable après 12 tentatives (~2 min)."
+  fi
+done
+```
+
+**Check navigateur** (une seule tentative après préflight OK) :
 
 ```bash
 # Sans sandbox : requis dans claude-worker (root dans container)
@@ -25,9 +46,12 @@ agent-browser open "$BASE_URL" \
   && agent-browser snapshot -i
 ```
 
-**Si l'environnement n'est pas joignable** :
+**Si l'environnement n'est pas joignable** (préflight curl ET browser échouent) :
 
-- `regression-tests` → afficher un message d'erreur et **STOP**.
+- `regression-tests` → créer une issue GitHub dédiée "TNR — env non joignable"
+  (labels `non-regression tests`, `env-unreachable`) décrivant le problème,
+  puis **STOP**. Ne jamais échouer silencieusement : la visibilité du problème
+  est obligatoire même si le workflow amont a déjà remonté l'erreur.
 - `browser-tests-on-demand` → marquer tous les scénarios `SKIP` (raison :
   "env non joignable"), compiler le rapport habituel, terminer avec code 0
   (le workflow appelant détruira l'env via `if: always()`).

--- a/.claude/skills/regression-tests/SKILL.md
+++ b/.claude/skills/regression-tests/SKILL.md
@@ -60,8 +60,35 @@ Redis, Celery — mais sans Traefik ni certificat TLS.
 ### 1.3 Vérification de l'environnement
 
 Lis la référence partagée `.claude/skills/_shared/browser-tests/environment.md`
-et applique le healthcheck. Pour `regression-tests`, si l'environnement n'est
-pas joignable : afficher un message d'erreur et **STOP**.
+et applique le healthcheck (préflight curl avec retries, puis check navigateur).
+
+**Si l'environnement reste non joignable** après tous les retries : **créer une
+issue GitHub dédiée** pour que le problème soit tracé (le workflow amont peut
+l'avoir déjà remonté côté CI, mais la visibilité côté issues est obligatoire) :
+
+```bash
+ENV_ISSUE_BODY="## ⚠️ Environnement non joignable
+
+Le healthcheck des tests de non-régression a échoué : \`${BASE_URL}\` ne
+répond pas (préflight curl + \`agent-browser open\` ont tous deux échoué
+après retries).
+
+**Date :** $(date -u '+%Y-%m-%d %H:%M UTC')
+**BASE_URL :** ${BASE_URL}
+
+Les scénarios ne seront pas exécutés. Vérifier :
+- l'état des containers \`blog-tnr-*\` sur le VPS
+- la connexion de \`claude-worker\` au réseau \`blog-tnr_default\`
+- les logs nginx / django de l'environnement éphémère"
+
+gh issue create \
+  --repo nicolasdeclerck/test-squad-automation \
+  --title "Tests de non-régression — Environnement non joignable $(date -u '+%Y-%m-%d')" \
+  --label "non-regression tests,env-unreachable" \
+  --body "$ENV_ISSUE_BODY"
+```
+
+Puis **STOP** (ne pas créer l'issue de suivi 1.5, ne pas lancer les scénarios).
 
 ### 1.4 Initialisation du rapport
 

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -57,9 +57,39 @@ jobs:
             ./scripts/tnr-docker.sh up
             docker network connect blog-tnr_default claude-worker || true
 
+      - name: Verify connectivity from claude-worker to test env
+        id: verify-env
+        if: steps.start-env.outcome == 'success'
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ubuntu
+          key: ${{ secrets.VPS_SSH_KEY }}
+          command_timeout: 3m
+          script: |
+            # Independent HTTP healthcheck run from the worker container so a
+            # transient "env non joignable" from the skill can be diagnosed as
+            # a Claude/browser problem vs. real infra breakage. Surfaces the
+            # failure at the workflow level (no continue-on-error) so the
+            # regression run turns red in the Actions UI instead of passing
+            # silently.
+            for i in $(seq 1 12); do
+              if docker exec claude-worker curl -sSf --max-time 10 -o /dev/null \
+                   http://blog-tnr-nginx-1:80/; then
+                echo "Environment reachable from claude-worker."
+                exit 0
+              fi
+              echo "Attempt $i/12 failed, retrying in 10s..."
+              sleep 10
+            done
+            echo "::error::Environment not reachable from claude-worker after 12 attempts (2 min)."
+            docker exec claude-worker curl -v --max-time 10 \
+              http://blog-tnr-nginx-1:80/ || true
+            exit 1
+
       - name: Run regression tests on VPS
         id: run-tests
-        if: steps.start-env.outcome == 'success'
+        if: steps.verify-env.outcome == 'success'
         uses: appleboy/ssh-action@v1
         continue-on-error: true
         with:
@@ -93,9 +123,10 @@ jobs:
             git checkout main || true
 
       - name: Handle failure (token quota or other error)
-        if: steps.run-tests.outcome == 'failure'
+        if: steps.run-tests.outcome == 'failure' || steps.verify-env.outcome == 'failure'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERIFY_ENV_OUTCOME: ${{ steps.verify-env.outcome }}
         run: |
           TRACKING_ISSUE=$(gh search issues "Tests de non-régression" \
             --repo ${{ github.repository }} \
@@ -103,21 +134,37 @@ jobs:
             --state open \
             --json number --jq '.[0].number // empty')
 
-          COMMENT_BODY="## ⚠️ Exécution interrompue
+          if [ "$VERIFY_ENV_OUTCOME" = "failure" ]; then
+            COMMENT_BODY="## ⚠️ Environnement non joignable
+
+          Les tests de non-régression n'ont pas pu démarrer : le healthcheck HTTP depuis \`claude-worker\` vers \`http://blog-tnr-nginx-1:80/\` a échoué après 12 tentatives (≈ 2 minutes).
+
+          **Date :** $(date -u '+%Y-%m-%d %H:%M UTC')
+          **Branche :** ${{ env.TNR_BRANCH }}
+          **Run :** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          L'environnement Docker éphémère a été démarré avec succès par \`tnr-docker.sh up\` mais n'a pas répondu sur le réseau partagé. Pistes : latence de démarrage, connexion \`claude-worker\` au réseau \`blog-tnr_default\`, DNS interne Docker, configuration nginx."
+            LABEL="env-unreachable"
+            TITLE="Tests de non-régression — Environnement non joignable $(date -u '+%Y-%m-%d')"
+          else
+            COMMENT_BODY="## ⚠️ Exécution interrompue
 
           Les tests de non-régression ont été interrompus suite à une erreur (dépassement des quotas de tokens de Claude Code ou autre problème technique).
 
           **Date :** $(date -u '+%Y-%m-%d %H:%M UTC')
 
           L'exécution devra être relancée manuellement une fois le problème résolu."
+            LABEL="standby"
+            TITLE="Tests de non-régression — Exécution interrompue $(date -u '+%Y-%m-%d')"
+          fi
 
           if [ -n "$TRACKING_ISSUE" ]; then
             gh issue comment "$TRACKING_ISSUE" --repo ${{ github.repository }} --body "$COMMENT_BODY"
-            gh issue edit "$TRACKING_ISSUE" --repo ${{ github.repository }} --add-label "standby"
+            gh issue edit "$TRACKING_ISSUE" --repo ${{ github.repository }} --add-label "$LABEL"
           else
             gh issue create \
               --repo ${{ github.repository }} \
-              --title "Tests de non-régression — Exécution interrompue $(date -u '+%Y-%m-%d')" \
-              --label "standby,non-regression tests" \
+              --title "$TITLE" \
+              --label "$LABEL,non-regression tests" \
               --body "$COMMENT_BODY"
           fi

--- a/scripts/tnr-docker.sh
+++ b/scripts/tnr-docker.sh
@@ -41,6 +41,27 @@ wait_for_django() {
     exit 1
 }
 
+wait_for_nginx() {
+    # Verify the full HTTP stack (nginx → django, nginx → frontend_dist) is
+    # actually serving requests before returning. Without this, the workflow
+    # can race and hand control to Claude while the env is only partially up,
+    # producing a misleading "environnement non joignable" from the skill.
+    echo "Waiting for nginx to serve HTTP on localhost:8080..."
+    local retries=30
+    while [ $retries -gt 0 ]; do
+        if curl -sSf --max-time 5 -o /dev/null "http://localhost:8080/"; then
+            echo "Nginx is serving."
+            return 0
+        fi
+        retries=$((retries - 1))
+        sleep 2
+    done
+    echo "ERROR: Nginx did not start serving HTTP in time."
+    $COMPOSE ps
+    $COMPOSE logs --tail=50 nginx django frontend
+    exit 1
+}
+
 seed_test_data() {
     echo "Seeding test data..."
     $COMPOSE exec -T django python manage.py shell <<'PYTHON'
@@ -85,6 +106,8 @@ cmd_up() {
     $COMPOSE exec -T django python manage.py migrate --noinput
 
     seed_test_data
+
+    wait_for_nginx
 
     echo ""
     echo "============================================"


### PR DESCRIPTION
Précédemment, quand l'environnement éphémère était indiqué comme non
joignable par le skill regression-tests, rien ne remontait : aucune
issue GitHub (la création d'issue arrivait *après* le healthcheck dans
le skill), et le workflow terminait en vert (continue-on-error sur le
step de tests + Claude exit 0 après "STOP").

Quatre défenses en profondeur :

- scripts/tnr-docker.sh : ajoute wait_for_nginx après seed_test_data.
  `up` ne retourne plus tant que nginx n'a pas répondu 2xx/3xx sur
  localhost:8080. Évite que start-env passe alors que l'env n'est pas
  encore servi.

- .github/workflows/regression-tests.yml : nouveau step verify-env qui
  teste la connectivité depuis claude-worker vers blog-tnr-nginx-1:80
  (12 × 10s). Sans continue-on-error : le workflow vire rouge si la
  connexion échoue. Le handler de failure crée désormais une issue
  dédiée avec le label env-unreachable quand c'est la cause.

- .claude/skills/_shared/browser-tests/environment.md : healthcheck
  préflight curl avec retries avant le check agent-browser, pour
  absorber les races de démarrage. Documente la nouvelle exigence :
  en cas de non-joignabilité, le skill regression-tests doit créer
  une issue GitHub avant de STOP.

- .claude/skills/regression-tests/SKILL.md : phase 1.3 impose la
  création d'une issue "Environnement non joignable" (labels
  non-regression tests + env-unreachable) avant le STOP.