### PR TITLE
fix: guard against undefined tags in PostDetail

### DIFF
--- a/frontend/src/components/blog/PostDetail.jsx
+++ b/frontend/src/components/blog/PostDetail.jsx
@@ -125,22 +125,25 @@ export default function PostDetail() {
       : post.content;
 
   // Sujet principal (utilisé pour le fil d'Ariane et le partage social).
-  const primaryTopic = post.tags[0].name.toUpperCase();
+  const primaryTopic =
+    post.tags && post.tags.length > 0 ? post.tags[0].name.toUpperCase() : null;
 
   return (
     <div className="max-w-6xl mx-auto px-4 py-12">
       <Helmet>
         <title>{displayTitle}</title>
-        <meta name="description" content={`${primaryTopic} — ${displayTitle}`} />
+        <meta name="description" content={primaryTopic ? `${primaryTopic} — ${displayTitle}` : displayTitle} />
       </Helmet>
 
       <div className="flex flex-col lg:flex-row lg:gap-8">
         {/* Article — colonne gauche */}
         <div className="flex-1 min-w-0">
           <article>
-            <p className="text-xs uppercase tracking-wide text-gray-500 mb-1">
-              {primaryTopic}
-            </p>
+            {primaryTopic && (
+              <p className="text-xs uppercase tracking-wide text-gray-500 mb-1">
+                {primaryTopic}
+              </p>
+            )}
             <h1 className="text-3xl font-bold text-gray-900 mb-2">{displayTitle}</h1>
             {post.tags && post.tags.length > 0 && (
               <div className="flex flex-wrap gap-1 mb-4">


### PR DESCRIPTION
## Description

Closes #201

Fix du crash Sentry `TypeError: undefined is not an object (evaluating 'n.tags[0].name')` qui se produit quand un article publié n'a aucun tag.

**Cause racine :** `PostDetail.jsx:128` accédait à `post.tags[0].name` sans vérifier que `tags` existe et contient des éléments.

**Fix :** Ajout d'une garde défensive `post.tags && post.tags.length > 0` avant d'accéder au premier tag, avec rendu conditionnel du label et de la meta description.

---

## Documentation

**Fichier modifié :** `frontend/src/components/blog/PostDetail.jsx` (1 fichier, 8 insertions, 5 suppressions)

### Changements
- `primaryTopic` retourne `null` si pas de tags (au lieu de crasher)
- Meta description utilise uniquement le titre quand pas de tag
- Le paragraphe fil d'Ariane n'est rendu que si un tag existe

### Vérification
1. Ouvrir un article publié sans tags → pas de crash
2. Ouvrir un article publié avec tags → tag principal affiché normalement