### PR TITLE
fix(tnr): remove prod fallback in regression-tests skill

### DIFF
--- a/.claude/skills/_shared/browser-tests/environment.md
+++ b/.claude/skills/_shared/browser-tests/environment.md
@@ -4,13 +4,17 @@ Partagé entre `regression-tests` et `browser-tests-on-demand`.
 
 ## Variables d'environnement attendues
 
-| Variable | Description | Défaut |
+| Variable | Description | Source |
 |----------|-------------|--------|
-| `BASE_URL` | URL frontend (nginx) de l'environnement testé | `https://blog.nickorp.com` (`regression-tests`) / injecté par le workflow (`browser-tests-on-demand`) |
+| `BASE_URL` | URL frontend (nginx) de l'environnement testé | **injecté par le workflow appelant** (`regression-tests.yml` / `browser-tests.yml`), pas de fallback |
 | `API_URL` | URL API de l'environnement testé | idem |
 
 Les deux skills construisent toutes leurs URLs à partir de `BASE_URL` (ex :
-`${BASE_URL}/comptes/connexion`).
+`${BASE_URL}/comptes/connexion`). **Pas de fallback** vers la production :
+si la variable n'est pas définie, le skill doit échouer immédiatement avec
+un message clair. Un fallback silencieux vers la prod a déjà causé un faux
+positif "env non joignable" (issue #202) : le skill visait
+`https://blog.nickorp.com` au lieu de l'env éphémère.
 
 ## Healthcheck initial
 

--- a/.claude/skills/regression-tests/SKILL.md
+++ b/.claude/skills/regression-tests/SKILL.md
@@ -22,32 +22,43 @@ Lis le fichier `docs/browser-test-checklist.md` pour récupérer :
 
 ### 1.2 Configuration des URLs cibles
 
-Les URLs cibles sont déterminées par les variables d'environnement
-`BASE_URL` et `API_URL`. Par défaut, elles pointent vers la production :
+Les URLs cibles sont lues **exclusivement** depuis les variables d'environnement
+`BASE_URL` et `API_URL` injectées par le workflow appelant.
+
+**Aucun fallback vers la production** : si `BASE_URL` n'est pas défini dans
+l'environnement du process, **arrêter immédiatement**. Ne jamais supposer une
+URL par défaut — viser accidentellement la prod pendant une TNR automatisée
+a déjà provoqué des faux "env non joignable" (issue #202).
 
 ```bash
-BASE_URL="${BASE_URL:-https://blog.nickorp.com}"
-API_URL="${API_URL:-https://blog.nickorp.com}"
+echo "=== Regression tests ==="
+echo "BASE_URL : ${BASE_URL:-(non défini)}"
+echo "API_URL  : ${API_URL:-(non défini)}"
+
+if [ -z "$BASE_URL" ] || [ -z "$API_URL" ]; then
+  echo "❌ BASE_URL ou API_URL non défini dans l'environnement. Arrêt."
+  echo "   Le skill doit être invoqué par un workflow qui injecte ces variables"
+  echo "   (ex: docker exec -e BASE_URL=... -e API_URL=... claude-worker claude -p ...)."
+  exit 1
+fi
 ```
 
-Si aucune variable d'environnement n'est définie, utiliser :
-- `BASE_URL=https://blog.nickorp.com`
-- `API_URL=https://blog.nickorp.com`
-
 Toutes les URLs utilisées dans les tests sont construites à partir de
-`BASE_URL` (ex : `${BASE_URL}/comptes/connexion`).
+`$BASE_URL` (ex : `${BASE_URL}/comptes/connexion`). **Ne jamais** écrire
+d'URL en dur, même comme exemple exécuté.
 
-#### Mode Docker local (environnement éphémère)
+#### Mode Docker local (développement)
 
-Pour exécuter les TNR sur un environnement Docker local identique à la
-production mais accessible uniquement en localhost :
+Pour exécuter les TNR manuellement sur l'environnement Docker éphémère :
 
 ```bash
 # 1. Démarrer l'environnement éphémère
 ./scripts/tnr-docker.sh up
 
-# 2. Lancer les tests avec BASE_URL sur localhost
-BASE_URL=http://localhost:8080 API_URL=http://localhost:8080 /regression-tests
+# 2. Exporter BASE_URL/API_URL avant de lancer le skill
+export BASE_URL=http://localhost:8080
+export API_URL=http://localhost:8080
+# puis /regression-tests
 
 # 3. Détruire l'environnement après les tests
 ./scripts/tnr-docker.sh down

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -101,11 +101,16 @@ jobs:
             docker exec claude-worker git -C /workspace/test-squad-automation fetch origin "${{ env.TNR_BRANCH }}"
             docker exec claude-worker git -C /workspace/test-squad-automation checkout "${{ env.TNR_BRANCH }}"
             docker exec claude-worker git -C /workspace/test-squad-automation pull origin "${{ env.TNR_BRANCH }}"
+            # BASE_URL/API_URL sont passés à la fois en env var (pour les
+            # commandes shell du skill) ET explicitement dans le prompt, pour
+            # empêcher le LLM de retomber sur un fallback documenté au lieu
+            # d'évaluer la variable (cf. faux positif issue #202 où Claude
+            # avait ciblé https://blog.nickorp.com).
             docker exec -i -w /workspace/test-squad-automation \
               -e BASE_URL=http://blog-tnr-nginx-1:80 \
               -e API_URL=http://blog-tnr-nginx-1:80 \
               claude-worker \
-              claude -p "Exécute le skill .claude/skills/regression-tests/SKILL.md" \
+              claude -p "Exécute le skill .claude/skills/regression-tests/SKILL.md. Les URLs à cibler sont strictement BASE_URL=http://blog-tnr-nginx-1:80 et API_URL=http://blog-tnr-nginx-1:80. N'utilise jamais d'autre URL (notamment pas https://blog.nickorp.com)." \
               --dangerously-skip-permissions --output-format json
 
       - name: Tear down test environment


### PR DESCRIPTION
Cause racine du faux "env non joignable" tracé dans l'issue #202 : le skill regression-tests avait documenté un fallback `BASE_URL=https://blog.nickorp.com` qui s'applique par défaut si BASE_URL n'est pas défini. Lors d'un run manuel du workflow depuis main, Claude a utilisé cette valeur par défaut au lieu de la variable d'env injectée par `docker exec -e BASE_URL=http://blog-tnr-nginx-1:80`, et a donc exécuté le healthcheck contre la production (https://blog.nickorp.com) au lieu de l'environnement Docker éphémère. Chromium headless a eu un souci sur la prod → "env non joignable" → STOP → issue #202 créée.

Fix :

- .claude/skills/regression-tests/SKILL.md : phase 1.2 exige BASE_URL / API_URL explicitement définis dans l'env et fait `exit 1` avec un message clair si l'une manque. Plus aucun fallback prod. Le mode dev local documente désormais `export BASE_URL=...` avant d'invoquer le skill.

- .claude/skills/_shared/browser-tests/environment.md : le tableau des variables d'environnement ne mentionne plus de "défaut prod" et rappelle explicitement le précédent (issue #202) pour empêcher la réintroduction du fallback.

- .github/workflows/regression-tests.yml : les URLs sont désormais passées à la fois en env var (comportement existant) **et** dans le prompt Claude, avec une instruction explicite de ne jamais cibler blog.nickorp.com. Belt-and-suspenders contre un LLM qui ignorerait la variable d'env au profit d'une valeur "documentée".