### PR TITLE
feat: close #211 - Épingler des articles à la une sur la page d'accueil

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,8 @@ class Post(models.Model):
     draft_title = models.CharField(max_length=200, blank=True)
     draft_content = models.TextField(blank=True)
     has_draft = models.BooleanField(default=False)
+    is_pinned = models.BooleanField(default=False, db_index=True)  # max 3 pinned
+    pinned_at = models.DateTimeField(null=True, blank=True)
     published_at = models.DateTimeField(null=True, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
 
@@ -142,6 +144,8 @@ class Profile(models.Model):
 /api/blog/posts/<slug>/cover-image/ → Upload (POST) et suppression (DELETE) de l'image de couverture
 /api/blog/posts/<slug>/autosave/   → Sauvegarde auto du brouillon
 /api/blog/posts/<slug>/publish/    → Publication d'un article
+/api/blog/posts/<slug>/pin/        → Épingle (POST) / désépingle (DELETE) un article publié (auteur, 3 max)
+/api/blog/posts/pinned/            → Liste publique des articles épinglés (tri par pinned_at desc)
 /api/blog/posts/<slug>/comments/   → Création de commentaire
 /api/blog/comments/<id>/           → Suppression de commentaire
 /api/blog/posts/<slug>/versions/   → Liste paginée des versions (auteur uniquement)

--- a/apps/blog/api_urls.py
+++ b/apps/blog/api_urls.py
@@ -8,6 +8,8 @@ from .api_views import (
     PostDetailAPIView,
     PostImageUploadView,
     PostListCreateAPIView,
+    PostPinnedListView,
+    PostPinView,
     PostPublishView,
     PostVersionDetailAPIView,
     PostVersionListAPIView,
@@ -30,6 +32,11 @@ urlpatterns = [
     ),
     path("posts/", PostListCreateAPIView.as_view(), name="api_post_list"),
     path(
+        "posts/pinned/",
+        PostPinnedListView.as_view(),
+        name="api_post_pinned_list",
+    ),
+    path(
         "posts/<slug:slug>/",
         PostDetailAPIView.as_view(),
         name="api_post_detail",
@@ -48,6 +55,11 @@ urlpatterns = [
         "posts/<slug:slug>/publish/",
         PostPublishView.as_view(),
         name="api_post_publish",
+    ),
+    path(
+        "posts/<slug:slug>/pin/",
+        PostPinView.as_view(),
+        name="api_post_pin",
     ),
     path(
         "posts/<slug:slug>/comments/",

--- a/apps/blog/api_views.py
+++ b/apps/blog/api_views.py
@@ -87,9 +87,7 @@ class PostListCreateAPIView(generics.ListCreateAPIView):
             and self.request.user.is_authenticated
             and self.request.user.is_superuser
         ):
-            return qs.filter(
-                status=Post.STATUS_DRAFT, author=self.request.user
-            )
+            return qs.filter(status=Post.STATUS_DRAFT, author=self.request.user)
         return qs.filter(status=Post.STATUS_PUBLISHED)
 
     def get_permissions(self):
@@ -113,9 +111,7 @@ class PostListCreateAPIView(generics.ListCreateAPIView):
         serializer.is_valid(raise_exception=True)
         self.perform_create(serializer)
         post = serializer.instance
-        detail_serializer = PostDetailSerializer(
-            post, context={"request": request}
-        )
+        detail_serializer = PostDetailSerializer(post, context={"request": request})
         return Response(detail_serializer.data, status=status.HTTP_201_CREATED)
 
 
@@ -133,9 +129,8 @@ class PostDetailAPIView(generics.RetrieveUpdateDestroyAPIView):
         return PostDetailSerializer
 
     def get_queryset(self):
-        qs = (
-            Post.objects.select_related("author__profile")
-            .prefetch_related("comments__author__profile", "tags")
+        qs = Post.objects.select_related("author__profile").prefetch_related(
+            "comments__author__profile", "tags"
         )
         if self.request.user.is_authenticated:
             return qs.filter(
@@ -154,16 +149,12 @@ class PostDetailAPIView(generics.RetrieveUpdateDestroyAPIView):
                 },
                 status=status.HTTP_403_FORBIDDEN,
             )
-        serializer = self.get_serializer(
-            instance, data=request.data, partial=partial
-        )
+        serializer = self.get_serializer(instance, data=request.data, partial=partial)
         serializer.is_valid(raise_exception=True)
         tag_names = serializer.validated_data.pop("tags", None)
         self.perform_update(serializer)
         _set_tags(instance, tag_names)
-        detail_serializer = PostDetailSerializer(
-            instance, context={"request": request}
-        )
+        detail_serializer = PostDetailSerializer(instance, context={"request": request})
         return Response(detail_serializer.data)
 
 
@@ -184,9 +175,7 @@ class PostAutoSaveView(APIView):
     permission_classes = [permissions.IsAuthenticated, IsSuperUser]
 
     def patch(self, request, slug):
-        post = generics.get_object_or_404(
-            Post, slug=slug, author=request.user
-        )
+        post = generics.get_object_or_404(Post, slug=slug, author=request.user)
         serializer = PostAutoSaveSerializer(post, data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)
         tag_names = serializer.validated_data.pop("tags", None)
@@ -199,18 +188,54 @@ class PostPublishView(APIView):
     permission_classes = [permissions.IsAuthenticated, IsSuperUser]
 
     def post(self, request, slug):
-        post = generics.get_object_or_404(
-            Post, slug=slug, author=request.user
-        )
+        post = generics.get_object_or_404(Post, slug=slug, author=request.user)
         if not (post.draft_title or "").strip() and not (post.title or "").strip():
             return Response(
                 {"error": "Le titre est requis pour publier."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         post.publish()
-        detail_serializer = PostDetailSerializer(
-            post, context={"request": request}
+        detail_serializer = PostDetailSerializer(post, context={"request": request})
+        return Response(detail_serializer.data)
+
+
+class PostPinnedListView(generics.ListAPIView):
+    """Return the ordered list of pinned posts (public)."""
+
+    serializer_class = PostListSerializer
+    permission_classes = [permissions.AllowAny]
+    pagination_class = None
+
+    def get_queryset(self):
+        return (
+            Post.objects.filter(is_pinned=True, status=Post.STATUS_PUBLISHED)
+            .select_related("author__profile")
+            .prefetch_related("tags")
+            .order_by("-pinned_at")
         )
+
+
+class PostPinView(APIView):
+    """Pin (POST) or unpin (DELETE) a published post (author only)."""
+
+    permission_classes = [permissions.IsAuthenticated, IsSuperUser]
+
+    def post(self, request, slug):
+        post = generics.get_object_or_404(Post, slug=slug, author=request.user)
+        try:
+            post.pin()
+        except ValidationError as exc:
+            return Response(
+                {"error": exc.messages[0] if exc.messages else str(exc)},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        detail_serializer = PostDetailSerializer(post, context={"request": request})
+        return Response(detail_serializer.data)
+
+    def delete(self, request, slug):
+        post = generics.get_object_or_404(Post, slug=slug, author=request.user)
+        post.unpin()
+        detail_serializer = PostDetailSerializer(post, context={"request": request})
         return Response(detail_serializer.data)
 
 
@@ -226,9 +251,7 @@ class PostVersionListAPIView(generics.ListAPIView):
     permission_classes = [permissions.IsAuthenticated]
 
     def get_queryset(self):
-        post = generics.get_object_or_404(
-            Post, slug=self.kwargs["slug"]
-        )
+        post = generics.get_object_or_404(Post, slug=self.kwargs["slug"])
         if post.author != self.request.user:
             self.permission_denied(self.request)
         return PostVersion.objects.filter(post=post)
@@ -240,9 +263,7 @@ class PostVersionDetailAPIView(generics.RetrieveAPIView):
     lookup_field = "version_number"
 
     def get_queryset(self):
-        post = generics.get_object_or_404(
-            Post, slug=self.kwargs["slug"]
-        )
+        post = generics.get_object_or_404(Post, slug=self.kwargs["slug"])
         if post.author != self.request.user:
             self.permission_denied(self.request)
         return PostVersion.objects.filter(post=post)
@@ -301,9 +322,7 @@ class PostCoverImageUploadView(APIView):
         try:
             post.full_clean()
         except ValidationError as e:
-            return Response(
-                e.message_dict, status=status.HTTP_400_BAD_REQUEST
-            )
+            return Response(e.message_dict, status=status.HTTP_400_BAD_REQUEST)
         post.save()
         return Response(
             {"url": post.cover_image.url},

--- a/apps/blog/migrations/0009_add_is_pinned_to_post.py
+++ b/apps/blog/migrations/0009_add_is_pinned_to_post.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("blog", "0008_add_cover_image_to_post"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="post",
+            name="is_pinned",
+            field=models.BooleanField(db_index=True, default=False),
+        ),
+        migrations.AddField(
+            model_name="post",
+            name="pinned_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+    ]

--- a/apps/blog/models.py
+++ b/apps/blog/models.py
@@ -40,9 +40,7 @@ def validate_post_image(image):
     except (FileNotFoundError, OSError, ValueError, AttributeError):
         raise ValidationError("Le fichier image est inaccessible.")
     if file_size > max_size:
-        raise ValidationError(
-            "La taille de l'image ne doit pas dépasser 10 Mo."
-        )
+        raise ValidationError("La taille de l'image ne doit pas dépasser 10 Mo.")
 
     try:
         if hasattr(image, "seek"):
@@ -62,9 +60,7 @@ def validate_post_image(image):
                 "Format non autorisé. Utilisez JPEG, PNG, WebP ou GIF."
             )
     except (UnidentifiedImageError, OSError, SyntaxError):
-        raise ValidationError(
-            "Format non autorisé. Utilisez JPEG, PNG, WebP ou GIF."
-        )
+        raise ValidationError("Format non autorisé. Utilisez JPEG, PNG, WebP ou GIF.")
 
 
 def validate_post_video(video):
@@ -74,17 +70,13 @@ def validate_post_video(video):
     except (FileNotFoundError, OSError, ValueError, AttributeError):
         raise ValidationError("Le fichier vidéo est inaccessible.")
     if file_size > max_size:
-        raise ValidationError(
-            "La taille de la vidéo ne doit pas dépasser 50 Mo."
-        )
+        raise ValidationError("La taille de la vidéo ne doit pas dépasser 50 Mo.")
 
     allowed_extensions = {".mp4", ".webm", ".ogg", ".ogv"}
     name = getattr(video, "name", "")
     _, ext = os.path.splitext(name.lower())
     if ext not in allowed_extensions:
-        raise ValidationError(
-            "Format non autorisé. Utilisez MP4, WebM ou OGG."
-        )
+        raise ValidationError("Format non autorisé. Utilisez MP4, WebM ou OGG.")
 
 
 class PostVideo(models.Model):
@@ -167,9 +159,7 @@ class Post(models.Model):
 
     title = models.CharField(max_length=200, blank=True)
     slug = models.SlugField(unique=True)
-    author = models.ForeignKey(
-        settings.AUTH_USER_MODEL, on_delete=models.CASCADE
-    )
+    author = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     content = models.TextField(blank=True)
     status = models.CharField(
         max_length=10, choices=STATUS_CHOICES, default=STATUS_DRAFT
@@ -184,11 +174,14 @@ class Post(models.Model):
         null=True,
         validators=[validate_post_image],
     )
+    is_pinned = models.BooleanField(default=False, db_index=True)
+    pinned_at = models.DateTimeField(null=True, blank=True)
     published_at = models.DateTimeField(null=True, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
 
     COVER_MAX_SIZE = (1200, 630)
     COVER_JPEG_QUALITY = 85
+    MAX_PINNED_POSTS = 3
 
     class Meta:
         ordering = ["-created_at"]
@@ -207,9 +200,7 @@ class Post(models.Model):
             self.published_at = timezone.now()
         self.save()
 
-        current_max = self.versions.aggregate(max_num=Max("version_number"))[
-            "max_num"
-        ]
+        current_max = self.versions.aggregate(max_num=Max("version_number"))["max_num"]
         next_version = (current_max or 0) + 1
         PostVersion.objects.create(
             post=self,
@@ -226,6 +217,29 @@ class Post(models.Model):
             self.cover_image, self.COVER_MAX_SIZE, self.COVER_JPEG_QUALITY
         )
         self.cover_image.save(name, content, save=False)
+
+    def pin(self):
+        """Pin this post to the homepage. Raises ValidationError if invalid."""
+        if self.status != self.STATUS_PUBLISHED:
+            raise ValidationError("Seuls les articles publiés peuvent être épinglés.")
+        if self.is_pinned:
+            return
+        pinned_count = Post.objects.filter(is_pinned=True).count()
+        if pinned_count >= self.MAX_PINNED_POSTS:
+            raise ValidationError(
+                f"Maximum {self.MAX_PINNED_POSTS} articles épinglés simultanément."
+            )
+        self.is_pinned = True
+        self.pinned_at = timezone.now()
+        self.save(update_fields=["is_pinned", "pinned_at"])
+
+    def unpin(self):
+        """Unpin this post from the homepage."""
+        if not self.is_pinned:
+            return
+        self.is_pinned = False
+        self.pinned_at = None
+        self.save(update_fields=["is_pinned", "pinned_at"])
 
     def save(self, *args, **kwargs):
         if not self.slug:
@@ -249,16 +263,16 @@ class Post(models.Model):
         """Check if cover_image has changed since last save."""
         if self.pk is None:
             return bool(self.cover_image)
-        old = Post.objects.filter(pk=self.pk).values_list(
-            "cover_image", flat=True
-        ).first()
+        old = (
+            Post.objects.filter(pk=self.pk)
+            .values_list("cover_image", flat=True)
+            .first()
+        )
         return old != self.cover_image.name
 
 
 class PostVersion(models.Model):
-    post = models.ForeignKey(
-        Post, on_delete=models.CASCADE, related_name="versions"
-    )
+    post = models.ForeignKey(Post, on_delete=models.CASCADE, related_name="versions")
     version_number = models.PositiveIntegerField()
     title = models.CharField(max_length=200)
     content = models.TextField()
@@ -284,12 +298,8 @@ class PostVersion(models.Model):
 
 
 class Comment(models.Model):
-    post = models.ForeignKey(
-        Post, on_delete=models.CASCADE, related_name="comments"
-    )
-    author = models.ForeignKey(
-        settings.AUTH_USER_MODEL, on_delete=models.CASCADE
-    )
+    post = models.ForeignKey(Post, on_delete=models.CASCADE, related_name="comments")
+    author = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     content = models.TextField()
     is_approved = models.BooleanField(default=False)
     created_at = models.DateTimeField(auto_now_add=True)

--- a/apps/blog/serializers.py
+++ b/apps/blog/serializers.py
@@ -64,9 +64,12 @@ class PostListSerializer(serializers.ModelSerializer):
             "plain_content",
             "reading_time_minutes",
             "has_draft",
+            "is_pinned",
+            "pinned_at",
             "published_at",
             "created_at",
         )
+        read_only_fields = ("is_pinned", "pinned_at")
 
     def get_reading_time_minutes(self, obj):
         """Estime le temps de lecture (en minutes) affiché sur la liste."""
@@ -80,7 +83,11 @@ class PostListSerializer(serializers.ModelSerializer):
 
     def get_has_draft(self, obj):
         request = self.context.get("request")
-        if request and request.user.is_authenticated and obj.author_id == request.user.id:
+        if (
+            request
+            and request.user.is_authenticated
+            and obj.author_id == request.user.id
+        ):
             return obj.has_draft
         return False
 
@@ -131,13 +138,20 @@ class PostDetailSerializer(serializers.ModelSerializer):
             "has_draft",
             "draft_title",
             "draft_content",
+            "is_pinned",
+            "pinned_at",
             "published_at",
             "created_at",
         )
+        read_only_fields = ("is_pinned", "pinned_at")
 
     def _is_author(self, obj):
         request = self.context.get("request")
-        return request and request.user.is_authenticated and obj.author_id == request.user.id
+        return (
+            request
+            and request.user.is_authenticated
+            and obj.author_id == request.user.id
+        )
 
     def get_is_owner(self, obj):
         return self._is_author(obj)
@@ -163,9 +177,7 @@ class PostDetailSerializer(serializers.ModelSerializer):
             .select_related("author__profile")
             .order_by("-created_at")
         )
-        return CommentSerializer(
-            comments, many=True, context=self.context
-        ).data
+        return CommentSerializer(comments, many=True, context=self.context).data
 
 
 class PostCreateUpdateSerializer(serializers.ModelSerializer):

--- a/apps/blog/tests/helpers.py
+++ b/apps/blog/tests/helpers.py
@@ -13,6 +13,13 @@ def api_publish_url(slug):
     return f"/api/blog/posts/{slug}/publish/"
 
 
+def api_pin_url(slug):
+    return f"/api/blog/posts/{slug}/pin/"
+
+
+API_POSTS_PINNED_URL = "/api/blog/posts/pinned/"
+
+
 def api_comments_url(slug):
     return f"/api/blog/posts/{slug}/comments/"
 

--- a/apps/blog/tests/test_api.py
+++ b/apps/blog/tests/test_api.py
@@ -11,6 +11,7 @@ from apps.blog.models import Post, PostImage, PostVideo
 
 from .factories import CommentFactory, PostFactory, PostVersionFactory
 from .helpers import (
+    API_POSTS_PINNED_URL,
     API_POSTS_URL,
     API_UPLOAD_IMAGE_URL,
     API_UPLOAD_VIDEO_URL,
@@ -18,6 +19,7 @@ from .helpers import (
     api_comment_delete_url,
     api_comments_url,
     api_cover_image_url,
+    api_pin_url,
     api_post_url,
     api_publish_url,
     api_version_detail_url,
@@ -64,7 +66,9 @@ class TestPostListAPI:
         assert author["last_name"] == "Dupont"
 
     def test_list_contains_plain_content(self):
-        PostFactory(content='[{"type":"paragraph","content":[{"type":"text","text":"Hello world"}]}]')
+        PostFactory(
+            content='[{"type":"paragraph","content":[{"type":"text","text":"Hello world"}]}]'
+        )
         response = self.client.get(API_POSTS_URL)
         data = response.json()
         assert "Hello world" in data["results"][0]["plain_content"]
@@ -231,9 +235,7 @@ class TestPostUpdateAPI:
 
     def test_update_own_draft_post(self):
         user = SuperUserFactory()
-        post = PostFactory(
-            author=user, status=Post.STATUS_DRAFT, title="Draft Title"
-        )
+        post = PostFactory(author=user, status=Post.STATUS_DRAFT, title="Draft Title")
         self.client.force_login(user)
         response = self.client.patch(
             api_post_url(post.slug),
@@ -368,10 +370,12 @@ class TestPostAutoSaveAPI:
         self.client.force_login(user)
         response = self.client.patch(
             api_autosave_url(post.slug),
-            data=json.dumps({
-                "draft_title": "Nouveau brouillon",
-                "draft_content": "Contenu brouillon",
-            }),
+            data=json.dumps(
+                {
+                    "draft_title": "Nouveau brouillon",
+                    "draft_content": "Contenu brouillon",
+                }
+            ),
             content_type="application/json",
         )
         assert response.status_code == 200
@@ -498,6 +502,165 @@ class TestPostPublishAPI:
 
 
 @pytest.mark.django_db
+class TestPostPinAPI:
+    def setup_method(self):
+        self.client = Client()
+
+    def test_pin_requires_auth(self):
+        post = PostFactory()
+        response = self.client.post(api_pin_url(post.slug))
+        assert response.status_code == 403
+
+    def test_pin_only_author(self):
+        post = PostFactory(author=SuperUserFactory())
+        other = SuperUserFactory()
+        self.client.force_login(other)
+        response = self.client.post(api_pin_url(post.slug))
+        assert response.status_code == 404
+
+    def test_pin_published_post(self):
+        user = SuperUserFactory()
+        post = PostFactory(author=user, status=Post.STATUS_PUBLISHED)
+        self.client.force_login(user)
+        response = self.client.post(api_pin_url(post.slug))
+        assert response.status_code == 200
+        post.refresh_from_db()
+        assert post.is_pinned is True
+        assert post.pinned_at is not None
+        assert response.json()["is_pinned"] is True
+
+    def test_pin_draft_returns_400(self):
+        user = SuperUserFactory()
+        post = PostFactory(
+            author=user,
+            status=Post.STATUS_DRAFT,
+            draft_title="x",
+            has_draft=True,
+        )
+        self.client.force_login(user)
+        response = self.client.post(api_pin_url(post.slug))
+        assert response.status_code == 400
+        assert (
+            "publiés" in response.json()["error"].lower()
+            or "publies" in response.json()["error"].lower()
+        )
+        post.refresh_from_db()
+        assert post.is_pinned is False
+
+    def test_pin_limit_enforced(self):
+        user = SuperUserFactory()
+        for _ in range(Post.MAX_PINNED_POSTS):
+            PostFactory(
+                author=user,
+                status=Post.STATUS_PUBLISHED,
+                is_pinned=True,
+            )
+        extra = PostFactory(author=user, status=Post.STATUS_PUBLISHED)
+        self.client.force_login(user)
+        response = self.client.post(api_pin_url(extra.slug))
+        assert response.status_code == 400
+        extra.refresh_from_db()
+        assert extra.is_pinned is False
+
+    def test_pin_limit_counts_across_authors(self):
+        """Le plafond est global, tous auteurs confondus."""
+        for _ in range(Post.MAX_PINNED_POSTS):
+            PostFactory(
+                author=SuperUserFactory(),
+                status=Post.STATUS_PUBLISHED,
+                is_pinned=True,
+            )
+        user = SuperUserFactory()
+        extra = PostFactory(author=user, status=Post.STATUS_PUBLISHED)
+        self.client.force_login(user)
+        response = self.client.post(api_pin_url(extra.slug))
+        assert response.status_code == 400
+
+    def test_unpin_resets_flag(self):
+        user = SuperUserFactory()
+        post = PostFactory(
+            author=user,
+            status=Post.STATUS_PUBLISHED,
+            is_pinned=True,
+        )
+        self.client.force_login(user)
+        response = self.client.delete(api_pin_url(post.slug))
+        assert response.status_code == 200
+        post.refresh_from_db()
+        assert post.is_pinned is False
+        assert post.pinned_at is None
+
+    def test_unpin_only_author(self):
+        post = PostFactory(
+            author=SuperUserFactory(),
+            status=Post.STATUS_PUBLISHED,
+            is_pinned=True,
+        )
+        other = SuperUserFactory()
+        self.client.force_login(other)
+        response = self.client.delete(api_pin_url(post.slug))
+        assert response.status_code == 404
+
+
+@pytest.mark.django_db
+class TestPostPinnedListAPI:
+    def setup_method(self):
+        self.client = Client()
+
+    def test_pinned_list_is_public(self):
+        response = self.client.get(API_POSTS_PINNED_URL)
+        assert response.status_code == 200
+
+    def test_pinned_list_returns_only_pinned_published(self):
+        from django.utils import timezone
+
+        pinned = PostFactory(
+            status=Post.STATUS_PUBLISHED,
+            is_pinned=True,
+            pinned_at=timezone.now(),
+        )
+        PostFactory(status=Post.STATUS_PUBLISHED, is_pinned=False)
+        PostFactory(status=Post.STATUS_DRAFT, is_pinned=True)
+
+        response = self.client.get(API_POSTS_PINNED_URL)
+        data = response.json()
+        slugs = [item["slug"] for item in data]
+        assert slugs == [pinned.slug]
+
+    def test_pinned_list_ordered_by_pinned_at_desc(self):
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        now = timezone.now()
+        oldest = PostFactory(
+            status=Post.STATUS_PUBLISHED,
+            is_pinned=True,
+            pinned_at=now - timedelta(hours=2),
+        )
+        middle = PostFactory(
+            status=Post.STATUS_PUBLISHED,
+            is_pinned=True,
+            pinned_at=now - timedelta(hours=1),
+        )
+        newest = PostFactory(
+            status=Post.STATUS_PUBLISHED,
+            is_pinned=True,
+            pinned_at=now,
+        )
+
+        response = self.client.get(API_POSTS_PINNED_URL)
+        data = response.json()
+        slugs = [item["slug"] for item in data]
+        assert slugs == [newest.slug, middle.slug, oldest.slug]
+
+    def test_pinned_list_empty_when_none(self):
+        PostFactory(status=Post.STATUS_PUBLISHED, is_pinned=False)
+        response = self.client.get(API_POSTS_PINNED_URL)
+        assert response.json() == []
+
+
+@pytest.mark.django_db
 class TestPostVersionListAPI:
     def setup_method(self):
         self.client = Client()
@@ -588,9 +751,7 @@ class TestPostVersionDetailAPI:
     def test_post_not_found(self):
         user = UserFactory()
         self.client.force_login(user)
-        response = self.client.get(
-            api_version_detail_url("nonexistent-slug", 1)
-        )
+        response = self.client.get(api_version_detail_url("nonexistent-slug", 1))
         assert response.status_code == 404
 
 
@@ -623,9 +784,7 @@ class TestPostVersionRestoreAPI:
         post = PostFactory(
             author=SuperUserFactory(), has_draft=False, status=Post.STATUS_PUBLISHED
         )
-        PostVersionFactory(
-            post=post, version_number=1, title="V1", content="C1"
-        )
+        PostVersionFactory(post=post, version_number=1, title="V1", content="C1")
         self.client.force_login(post.author)
         self.client.post(api_version_restore_url(post.slug, 1))
         post.refresh_from_db()
@@ -820,10 +979,12 @@ class TestContinuousDraftWorkflow:
         # Step 3: Autosave modifications
         response = self.client.patch(
             api_autosave_url(slug),
-            data=json.dumps({
-                "draft_title": "Mon article V2",
-                "draft_content": "Contenu V2",
-            }),
+            data=json.dumps(
+                {
+                    "draft_title": "Mon article V2",
+                    "draft_content": "Contenu V2",
+                }
+            ),
             content_type="application/json",
         )
         assert response.status_code == 200
@@ -882,7 +1043,12 @@ def _create_test_image(fmt="JPEG", size=(100, 100)):
     img.save(buf, format=fmt)
     buf.seek(0)
     ext = {"JPEG": "jpg", "PNG": "png", "WEBP": "webp", "GIF": "gif"}[fmt]
-    content_type = {"JPEG": "image/jpeg", "PNG": "image/png", "WEBP": "image/webp", "GIF": "image/gif"}[fmt]
+    content_type = {
+        "JPEG": "image/jpeg",
+        "PNG": "image/png",
+        "WEBP": "image/webp",
+        "GIF": "image/gif",
+    }[fmt]
     return SimpleUploadedFile(f"test.{ext}", buf.read(), content_type=content_type)
 
 
@@ -964,9 +1130,7 @@ def _create_test_video(fmt="mp4", size_bytes=1024):
     # Minimal valid-looking video content (not a real video, but enough for
     # the validator which checks mime type by extension, not file content)
     data = b"\x00" * size_bytes
-    return SimpleUploadedFile(
-        f"test.{fmt}", data, content_type=content_types[fmt]
-    )
+    return SimpleUploadedFile(f"test.{fmt}", data, content_type=content_types[fmt])
 
 
 @pytest.mark.django_db

--- a/apps/blog/tests/test_models.py
+++ b/apps/blog/tests/test_models.py
@@ -1,6 +1,7 @@
 from io import BytesIO
 
 import pytest
+from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db import IntegrityError
 from PIL import Image
@@ -17,9 +18,7 @@ def _make_test_image(width, height, fmt="JPEG", mode="RGB"):
     img.save(buf, format=fmt)
     buf.seek(0)
     ext = {"JPEG": "jpg", "PNG": "png", "WEBP": "webp", "GIF": "gif"}[fmt]
-    return SimpleUploadedFile(
-        f"test.{ext}", buf.read(), content_type=f"image/{ext}"
-    )
+    return SimpleUploadedFile(f"test.{ext}", buf.read(), content_type=f"image/{ext}")
 
 
 @pytest.mark.django_db
@@ -125,6 +124,59 @@ class TestPostModel:
 
 
 @pytest.mark.django_db
+class TestPostPinning:
+    def test_is_pinned_default_false(self):
+        post = PostFactory()
+        assert post.is_pinned is False
+        assert post.pinned_at is None
+
+    def test_pin_sets_flag_and_timestamp(self):
+        post = PostFactory(status=Post.STATUS_PUBLISHED)
+        post.pin()
+        post.refresh_from_db()
+        assert post.is_pinned is True
+        assert post.pinned_at is not None
+
+    def test_pin_draft_raises(self):
+        post = PostFactory(status=Post.STATUS_DRAFT, draft_title="x")
+        with pytest.raises(ValidationError):
+            post.pin()
+        post.refresh_from_db()
+        assert post.is_pinned is False
+
+    def test_pin_limit_of_three_enforced(self):
+        for _ in range(Post.MAX_PINNED_POSTS):
+            PostFactory(status=Post.STATUS_PUBLISHED, is_pinned=True)
+        extra = PostFactory(status=Post.STATUS_PUBLISHED)
+        with pytest.raises(ValidationError):
+            extra.pin()
+        extra.refresh_from_db()
+        assert extra.is_pinned is False
+
+    def test_pin_idempotent(self):
+        post = PostFactory(status=Post.STATUS_PUBLISHED)
+        post.pin()
+        first_ts = post.pinned_at
+        post.pin()
+        post.refresh_from_db()
+        assert post.is_pinned is True
+        assert post.pinned_at == first_ts
+
+    def test_unpin_resets_flag_and_timestamp(self):
+        post = PostFactory(status=Post.STATUS_PUBLISHED)
+        post.pin()
+        post.unpin()
+        post.refresh_from_db()
+        assert post.is_pinned is False
+        assert post.pinned_at is None
+
+    def test_unpin_idempotent(self):
+        post = PostFactory(status=Post.STATUS_PUBLISHED)
+        post.unpin()
+        assert post.is_pinned is False
+
+
+@pytest.mark.django_db
 class TestCommentModel:
     def test_is_approved_false_by_default(self):
         comment = CommentFactory()
@@ -181,9 +233,7 @@ class TestPostImageCompression:
     def test_large_image_is_resized(self):
         """Image larger than 1920x1080 is resized down."""
         user = UserFactory()
-        post_image = PostImage(
-            image=_make_test_image(3000, 2000), uploaded_by=user
-        )
+        post_image = PostImage(image=_make_test_image(3000, 2000), uploaded_by=user)
         post_image.save()
 
         img = Image.open(post_image.image)
@@ -194,9 +244,7 @@ class TestPostImageCompression:
     def test_small_image_not_upscaled(self):
         """Image smaller than max size keeps its dimensions."""
         user = UserFactory()
-        post_image = PostImage(
-            image=_make_test_image(800, 600), uploaded_by=user
-        )
+        post_image = PostImage(image=_make_test_image(800, 600), uploaded_by=user)
         post_image.save()
 
         img = Image.open(post_image.image)

--- a/docs/browser-test-checklist.md
+++ b/docs/browser-test-checklist.md
@@ -211,10 +211,59 @@
 - **Vérifications** :
   - Un bouton "..." (trois points) est visible à droite du titre de la carte
   - Le bouton "..." n'est PAS visible pour un utilisateur non-auteur ou non-superutilisateur
-  - Clic sur "..." ouvre un dropdown (menu déroulant) contenant les actions "Modifier" et "Supprimer"
+  - Clic sur "..." ouvre un dropdown (menu déroulant) contenant les actions "Modifier", "Supprimer" et "Épingler/Désépingler"
   - Clic sur "Modifier" dans le dropdown redirige vers `/articles/{slug}/modifier`
   - Clic sur "Supprimer" dans le dropdown redirige vers `/articles/{slug}/supprimer`
   - Le dropdown se ferme correctement au clic extérieur ou après sélection d'une action
+
+### 3.9 — [PUBLIC] Section « À la une » sur la page d'accueil
+
+- **URL** : `/` (page d'accueil avec au moins un article épinglé)
+- **Vérifications** :
+  - Une section « À la une » est affichée **au-dessus** de la liste « Derniers articles » lorsqu'au moins un article est épinglé
+  - Les articles épinglés sont affichés sous forme de cartes hero (image de couverture, titre, tags, auteur, date, extrait)
+  - L'image de couverture des cartes « À la une » est plus grande que sur les cartes classiques
+  - En desktop (≥ 1024px), la section utilise une grille de **3 colonnes**
+  - En mobile (< 768px), les cartes sont affichées en **1 colonne**
+  - Les articles épinglés apparaissent **aussi** dans la liste « Derniers articles » (pas de déduplication)
+  - Si aucun article n'est épinglé, la section « À la une » n'est PAS affichée
+
+### 3.10 — [AUTH/OWNER] Action rapide « Épingler » depuis une carte d'article
+
+- **URL** : `/` ou `/articles` (en tant qu'auteur superutilisateur d'un article publié)
+- **Vérifications** :
+  - Une option « Épingler à la une » (ou « Désépingler ») est présente dans le dropdown `...` de la carte
+  - L'action n'est disponible que pour les articles **publiés** (pas pour un brouillon)
+  - Clic sur « Épingler à la une » appelle `POST /api/blog/posts/{slug}/pin/` et l'article apparaît dans la section « À la une » après rechargement
+  - Clic sur « Désépingler » appelle `DELETE /api/blog/posts/{slug}/pin/` et l'article quitte la section « À la une » après rechargement
+  - L'option est ABSENTE pour un utilisateur non-auteur
+  - L'option est ABSENTE pour un visiteur non connecté
+
+### 3.11 — [AUTH/OWNER] Action rapide « Épingler » depuis la page détail d'un article
+
+- **URL** : `/articles/{slug}` (article publié, en tant qu'auteur superutilisateur)
+- **Vérifications** :
+  - Un bouton « Épingler à la une » / « Désépingler » est visible dans la barre d'actions sous le titre (à côté de « Modifier » / « Supprimer »)
+  - Le libellé du bouton reflète l'état courant (`is_pinned`)
+  - Clic sur le bouton appelle l'API pin/unpin et le libellé est mis à jour après succès
+  - Le bouton est ABSENT pour un utilisateur non-auteur
+  - Le bouton est ABSENT pour un article en statut `draft`
+
+### 3.12 — [AUTH/OWNER] Limite de 3 articles épinglés
+
+- **URL** : `/articles/{slug}` (4e article publié de l'auteur, alors que 3 sont déjà épinglés)
+- **Vérifications** :
+  - Cliquer sur « Épingler à la une » pour un 4e article **échoue** : l'API renvoie 400
+  - Un message d'erreur explicite s'affiche côté UI (ex : « Maximum 3 articles épinglés simultanément »)
+  - L'article n'est pas ajouté à la section « À la une »
+  - Après avoir désépinglé un autre article, l'opération réussit
+
+### 3.13 — [AUTH/OWNER] Badge « Épinglé » sur les cartes d'articles
+
+- **URL** : `/` ou `/articles` (carte d'un article épinglé)
+- **Vérifications** :
+  - Un badge ou icône « Épinglé » est visible sur la carte pour indiquer l'état épinglé (visible pour tous les visiteurs, publics ou connectés)
+  - Le badge est ABSENT pour un article non épinglé
 
 ---
 
@@ -812,6 +861,22 @@
 16. Vérifier que le contenu mis à jour est affiché
 17. Vérifier dans "Historique des versions" qu'une nouvelle version a été créée
 18. Vérifier dans la liste des articles que le badge "brouillon en cours" a disparu
+
+### 13.9 — Parcours complet : épinglage d'articles à la une
+
+1. Se connecter avec l'utilisateur 1 (superutilisateur)
+2. Créer et publier 4 articles A1, A2, A3, A4
+3. Ouvrir `/articles/{A1.slug}` et cliquer sur « Épingler à la une »
+4. Vérifier que le bouton devient « Désépingler »
+5. Répéter pour A2 et A3
+6. Ouvrir `/` et vérifier que la section « À la une » est affichée avec A1, A2, A3 sous forme de cartes hero (3 colonnes desktop)
+7. Vérifier que A1, A2, A3 apparaissent **aussi** dans la liste « Derniers articles »
+8. Ouvrir `/articles/{A4.slug}` et cliquer sur « Épingler à la une »
+9. Vérifier qu'un message d'erreur s'affiche (limite de 3 atteinte) et que A4 n'apparaît PAS dans la section « À la une »
+10. Désépingler A1 depuis le menu contextuel de la carte, puis épingler A4
+11. Vérifier que A4 apparaît maintenant dans « À la une » et A1 n'y est plus
+12. Se déconnecter, puis vérifier que la section « À la une » reste visible en mode public (avec A2, A3, A4)
+13. Se connecter avec l'utilisateur 2 (non-auteur des articles) et vérifier que les boutons « Épingler/Désépingler » sont ABSENTS
 
 ### 13.8 — Parcours complet : édition continue d'un article publié (brouillon continu)
 

--- a/frontend/src/components/blog/FeaturedPosts.jsx
+++ b/frontend/src/components/blog/FeaturedPosts.jsx
@@ -1,0 +1,79 @@
+import { Badge } from "@mantine/core";
+import { Link } from "react-router-dom";
+import Avatar from "../ui/Avatar";
+
+function FeaturedCard({ post }) {
+  const authorName =
+    post.author.first_name && post.author.last_name
+      ? `${post.author.first_name} ${post.author.last_name}`
+      : post.author.username;
+  const date = new Date(
+    post.published_at || post.created_at
+  ).toLocaleDateString("fr-FR");
+  const excerpt = post.plain_content
+    ? post.plain_content.split(" ").slice(0, 30).join(" ") +
+      (post.plain_content.split(" ").length > 30 ? "..." : "")
+    : "";
+
+  return (
+    <article className="flex flex-col overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm hover:shadow-md transition-shadow">
+      <Link to={`/articles/${post.slug}`} className="block">
+        {post.cover_image ? (
+          <img
+            src={post.cover_image}
+            alt={post.title}
+            className="w-full h-56 object-cover"
+          />
+        ) : (
+          <div className="w-full h-56 bg-gradient-to-br from-blue-50 to-gray-100" />
+        )}
+      </Link>
+      <div className="flex flex-1 flex-col p-5">
+        <h3 className="text-lg font-semibold text-gray-900">
+          <Link
+            to={`/articles/${post.slug}`}
+            className="hover:underline"
+          >
+            {post.title}
+          </Link>
+        </h3>
+        {post.tags && post.tags.length > 0 && (
+          <div className="flex flex-wrap gap-1 mt-1">
+            {post.tags.map((tag) => (
+              <Badge key={tag.id} size="xs" variant="light" color="blue">
+                {tag.name}
+              </Badge>
+            ))}
+          </div>
+        )}
+        {excerpt && (
+          <p className="text-sm text-gray-600 mt-3 leading-relaxed flex-1">
+            {excerpt}
+          </p>
+        )}
+        <div className="flex items-center gap-2 mt-4">
+          <Avatar user={post.author} size="sm" />
+          <p className="text-xs text-gray-500">
+            {authorName} &mdash; {date}
+          </p>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export default function FeaturedPosts({ posts }) {
+  if (!posts || posts.length === 0) return null;
+  return (
+    <section className="mb-10">
+      <h2 className="text-xl font-semibold text-gray-900 mb-4">
+        À la une
+      </h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {posts.map((post) => (
+          <FeaturedCard key={post.id} post={post} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/blog/PostCard.jsx
+++ b/frontend/src/components/blog/PostCard.jsx
@@ -1,11 +1,39 @@
 import { Link } from "react-router-dom";
 import { Badge, Menu } from "@mantine/core";
+import { notifications } from "@mantine/notifications";
+import { useState } from "react";
+import { api } from "../../api/client";
 import { useAuth } from "../../contexts/AuthContext";
 import Avatar from "../ui/Avatar";
 
-export default function PostCard({ post }) {
+export default function PostCard({ post: initialPost, onChange }) {
   const { user } = useAuth();
+  const [post, setPost] = useState(initialPost);
+  const [pinToggling, setPinToggling] = useState(false);
   const canEdit = user && user.is_superuser && post.author && user.id === post.author.id;
+  const canPin = canEdit && post.status === "published";
+
+  const handleTogglePin = async () => {
+    if (pinToggling) return;
+    setPinToggling(true);
+    const res = post.is_pinned
+      ? await api.delete(`/api/blog/posts/${post.slug}/pin/`)
+      : await api.post(`/api/blog/posts/${post.slug}/pin/`);
+    setPinToggling(false);
+    if (res.ok) {
+      setPost(res.data);
+      if (onChange) onChange(res.data);
+    } else {
+      notifications.show({
+        title: "Épinglage impossible",
+        message:
+          res.errors?.error ||
+          res.errors?.detail ||
+          "Erreur lors de l'épinglage.",
+        color: "red",
+      });
+    }
+  };
 
   const authorName =
     post.author.first_name && post.author.last_name
@@ -43,6 +71,28 @@ export default function PostCard({ post }) {
                 </Badge>
               ))}
             </div>
+          )}
+          {post.is_pinned && (
+            <span
+              className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 mt-1"
+              title="Article épinglé à la une"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="currentColor"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+                className="size-3"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M9 4.5v4.5l-3 3v2.25h12V12l-3-3V4.5m-6 9v6m3-10.5h.008v.008H12V7.5Z"
+                />
+              </svg>
+              Épinglé
+            </span>
           )}
           {canEdit && post.has_draft && post.status === "published" && (
             <span
@@ -120,6 +170,30 @@ export default function PostCard({ post }) {
               >
                 Modifier
               </Menu.Item>
+              {canPin && (
+                <Menu.Item
+                  onClick={handleTogglePin}
+                  disabled={pinToggling}
+                  leftSection={
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill={post.is_pinned ? "currentColor" : "none"}
+                      viewBox="0 0 24 24"
+                      strokeWidth={1.5}
+                      stroke="currentColor"
+                      className="size-5"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M9 4.5v4.5l-3 3v2.25h12V12l-3-3V4.5m-6 9v6m3-10.5h.008v.008H12V7.5Z"
+                      />
+                    </svg>
+                  }
+                >
+                  {post.is_pinned ? "Désépingler" : "Épingler à la une"}
+                </Menu.Item>
+              )}
               <Menu.Item
                 component={Link}
                 to={`/articles/${post.slug}/supprimer`}

--- a/frontend/src/components/blog/PostDetail.jsx
+++ b/frontend/src/components/blog/PostDetail.jsx
@@ -2,6 +2,7 @@ import "@blocknote/core/fonts/inter.css";
 import "@blocknote/mantine/style.css";
 import { useCreateBlockNote } from "@blocknote/react";
 import { Alert, Badge } from "@mantine/core";
+import { notifications } from "@mantine/notifications";
 import DOMPurify from "dompurify";
 import { useEffect, useMemo, useState } from "react";
 import { Helmet } from "react-helmet-async";
@@ -59,6 +60,7 @@ export default function PostDetail() {
   const [publishing, setPublishing] = useState(false);
   const [publishError, setPublishError] = useState("");
   const [hasVersions, setHasVersions] = useState(false);
+  const [pinToggling, setPinToggling] = useState(false);
 
   const handlePublish = async () => {
     setPublishing(true);
@@ -72,6 +74,27 @@ export default function PostDetail() {
       );
     }
     setPublishing(false);
+  };
+
+  const handleTogglePin = async () => {
+    if (!post || pinToggling) return;
+    setPinToggling(true);
+    const res = post.is_pinned
+      ? await api.delete(`/api/blog/posts/${post.slug}/pin/`)
+      : await api.post(`/api/blog/posts/${post.slug}/pin/`);
+    setPinToggling(false);
+    if (res.ok) {
+      setPost(res.data);
+    } else {
+      notifications.show({
+        title: "Épinglage impossible",
+        message:
+          res.errors?.error ||
+          res.errors?.detail ||
+          "Erreur lors de l'épinglage.",
+        color: "red",
+      });
+    }
   };
 
   useEffect(() => {
@@ -229,6 +252,32 @@ export default function PostDetail() {
                       : post.status === "published"
                         ? "Publier les modifications"
                         : "Publier"}
+                  </button>
+                )}
+                {post.status === "published" && (
+                  <button
+                    onClick={handleTogglePin}
+                    disabled={pinToggling}
+                    className="inline-flex items-center gap-1 rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors disabled:opacity-50"
+                    title={
+                      post.is_pinned ? "Désépingler" : "Épingler à la une"
+                    }
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill={post.is_pinned ? "currentColor" : "none"}
+                      viewBox="0 0 24 24"
+                      strokeWidth={1.5}
+                      stroke="currentColor"
+                      className="size-4"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M9 4.5v4.5l-3 3v2.25h12V12l-3-3V4.5m-6 9v6m3-10.5h.008v.008H12V7.5Z"
+                      />
+                    </svg>
+                    {post.is_pinned ? "Désépingler" : "Épingler à la une"}
                   </button>
                 )}
                 {hasVersions && (

--- a/frontend/src/components/blog/PostForm.jsx
+++ b/frontend/src/components/blog/PostForm.jsx
@@ -2,7 +2,7 @@ import "@blocknote/core/fonts/inter.css";
 import "@blocknote/mantine/style.css";
 import { BlockNoteView } from "@blocknote/mantine";
 import { useCreateBlockNote } from "@blocknote/react";
-import { TagsInput } from "@mantine/core";
+import { Switch, TagsInput } from "@mantine/core";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Helmet } from "react-helmet-async";
 import { Link, useBlocker, useNavigate, useParams } from "react-router-dom";
@@ -88,6 +88,9 @@ export default function PostForm() {
   const [lastSavedAt, setLastSavedAt] = useState(null);
   const [coverImage, setCoverImage] = useState(null);
   const [coverImageUploading, setCoverImageUploading] = useState(false);
+  const [isPinned, setIsPinned] = useState(false);
+  const [postStatus, setPostStatus] = useState("");
+  const [pinToggling, setPinToggling] = useState(false);
   const coverImageFileRef = useRef(null);
   const coverBlobUrlRef = useRef(null);
   const titleRef = useRef(null);
@@ -122,6 +125,8 @@ export default function PostForm() {
           if (res.data.cover_image) {
             setCoverImage(res.data.cover_image);
           }
+          setIsPinned(Boolean(res.data.is_pinned));
+          setPostStatus(res.data.status || "");
           try {
             const parsed = JSON.parse(editContent);
             setInitialContent(parsed);
@@ -347,6 +352,29 @@ export default function PostForm() {
     }
   };
 
+  const handlePinToggle = async (event) => {
+    const nextPinned = event.currentTarget.checked;
+    if (!slug || pinToggling) return;
+    setPinToggling(true);
+    const res = nextPinned
+      ? await api.post(`/api/blog/posts/${slug}/pin/`)
+      : await api.delete(`/api/blog/posts/${slug}/pin/`);
+    setPinToggling(false);
+    if (res.ok) {
+      setIsPinned(Boolean(res.data.is_pinned));
+    } else {
+      const message =
+        res.errors?.error ||
+        res.errors?.detail ||
+        "Erreur lors de l'épinglage.";
+      notifications.show({
+        title: "Épinglage impossible",
+        message,
+        color: "red",
+      });
+    }
+  };
+
   const handleCoverImageDelete = async () => {
     if (coverBlobUrlRef.current) {
       URL.revokeObjectURL(coverBlobUrlRef.current);
@@ -546,6 +574,18 @@ export default function PostForm() {
             clearable
           />
         </div>
+
+        {isEdit && postStatus === "published" && (
+          <div className="mb-5">
+            <Switch
+              checked={isPinned}
+              onChange={handlePinToggle}
+              disabled={pinToggling}
+              label="Épingler à la une"
+              description="L'article apparaîtra dans la section « À la une » de la page d'accueil (3 max)."
+            />
+          </div>
+        )}
 
         {isEdit && <SaveStatusIndicator saveStatus={saveStatus} lastSavedAt={lastSavedAt} />}
 

--- a/frontend/src/components/blog/PostList.jsx
+++ b/frontend/src/components/blog/PostList.jsx
@@ -1,17 +1,28 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Helmet } from "react-helmet-async";
 import { Link, useSearchParams } from "react-router-dom";
 import { api } from "../../api/client";
 import Pagination from "../ui/Pagination";
+import FeaturedPosts from "./FeaturedPosts";
 import PostCard from "./PostCard";
 
 export default function PostList({ isHome = false }) {
   const [posts, setPosts] = useState([]);
+  const [pinnedPosts, setPinnedPosts] = useState([]);
   const [totalPages, setTotalPages] = useState(1);
   const [showFullListLink, setShowFullListLink] = useState(false);
   const [loading, setLoading] = useState(true);
   const [searchParams, setSearchParams] = useSearchParams();
   const page = parseInt(searchParams.get("page") || "1", 10);
+
+  const fetchPinned = useCallback(() => {
+    if (!isHome) return;
+    api.get("/api/blog/posts/pinned/").then((res) => {
+      if (res.ok) {
+        setPinnedPosts(Array.isArray(res.data) ? res.data : []);
+      }
+    });
+  }, [isHome]);
 
   useEffect(() => {
     setLoading(true);
@@ -30,7 +41,18 @@ export default function PostList({ isHome = false }) {
       }
       setLoading(false);
     });
-  }, [page, isHome]);
+    fetchPinned();
+  }, [page, isHome, fetchPinned]);
+
+  const handlePostChange = useCallback(
+    (updated) => {
+      setPosts((prev) =>
+        prev.map((p) => (p.id === updated.id ? { ...p, ...updated } : p))
+      );
+      fetchPinned();
+    },
+    [fetchPinned]
+  );
 
   if (loading) {
     return (
@@ -55,6 +77,10 @@ export default function PostList({ isHome = false }) {
           }
         />
       </Helmet>
+      {isHome && pinnedPosts.length > 0 && (
+        <FeaturedPosts posts={pinnedPosts} />
+      )}
+
       <div className="flex items-center justify-between mb-8">
         <h1 className="text-3xl font-bold text-gray-900">{title}</h1>
         {!isHome && (
@@ -71,7 +97,11 @@ export default function PostList({ isHome = false }) {
         <>
           <div>
             {posts.map((post) => (
-              <PostCard key={post.id} post={post} />
+              <PostCard
+                key={post.id}
+                post={post}
+                onChange={handlePostChange}
+              />
             ))}
           </div>
 


### PR DESCRIPTION
## Description

Closes #211

Ajout d'un système d'épinglage d'articles à la une :
- Champs `is_pinned` / `pinned_at` sur `Post`, limite globale de 3
- Endpoints `POST/DELETE /api/blog/posts/<slug>/pin/` (auteur) et `GET /api/blog/posts/pinned/` (public)
- Section « À la une » sur la page d'accueil (grille responsive 3/2/1 colonnes)
- Contrôles Épingler/Désépingler dans l'éditeur, sur la page détail et dans le menu des cartes
- Badge « Épinglé » sur les cartes d'articles épinglés
- 19 nouveaux tests (7 unitaires modèle + 12 intégration API)
- Cahier de tests browser mis à jour (6 scénarios + parcours E2E)

---

## Test plan

- [x] Tests unitaires `TestPostPinning` passent (7/7)
- [x] Tests d'intégration `TestPostPinAPI` + `TestPostPinnedListAPI` passent (12/12)
- [x] Build frontend OK (`vite build`)
- [ ] Exécuter la non-régression browser après merge (scénarios 3.9 à 3.13 et 13.9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)