### PR TITLE
chore(ci): disable non-prod workflows temporarily

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -20,6 +20,7 @@ permissions:
 
 jobs:
   browser-tests:
+    if: false  # Temporairement désactivé
     runs-on: ubuntu-latest
     steps:
       - name: Check Claude MAX session

--- a/.github/workflows/lint-skills.yml
+++ b/.github/workflows/lint-skills.yml
@@ -18,6 +18,7 @@ permissions:
 
 jobs:
   lint-skills:
+    if: false  # Temporairement désactivé
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   regression-tests:
+    if: false  # Temporairement désactivé
     runs-on: ubuntu-latest
     steps:
       - name: Check for recent merges on main

--- a/.github/workflows/ticket-workflow.yml
+++ b/.github/workflows/ticket-workflow.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   ticket-workflow:
-    if: github.event.label.name == 'analyze'
+    if: false  # Temporairement désactivé (condition originale: github.event.label.name == 'analyze')
     runs-on: ubuntu-latest
     steps:
       - name: Check Claude MAX session


### PR DESCRIPTION
## Summary
- Désactive temporairement les 4 workflows GitHub Actions non-prod via `if: false` au niveau du job : `browser-tests`, `lint-skills`, `regression-tests`, `ticket-workflow`
- `deploy-prod.yml` reste actif
- Pour `ticket-workflow`, la condition originale (`github.event.label.name == 'analyze'`) est conservée en commentaire pour faciliter la réactivation

## Why
Désactivation temporaire demandée pour ne conserver que le déploiement en production.

## Réactivation
Retirer les lignes `if: false  # Temporairement désactivé` dans les 4 fichiers, et restaurer la condition originale dans `ticket-workflow.yml`.

## Test plan
- [ ] Vérifier qu'un push sur une branche non-main ne déclenche plus `lint-skills`
- [ ] Vérifier qu'un label `analyze` sur une issue ne déclenche plus `ticket-workflow`
- [ ] Vérifier qu'un merge sur `main` déclenche toujours `deploy-prod`

🤖 Generated with [Claude Code](https://claude.com/claude-code)