### PR TITLE
fix: close #216 - ZeroDivisionError sur la liste des articles (impossible d'enregistrer un brouillon)

### DIFF
--- a/apps/blog/serializers.py
+++ b/apps/blog/serializers.py
@@ -75,6 +75,8 @@ class PostListSerializer(serializers.ModelSerializer):
         """Estime le temps de lecture (en minutes) affiché sur la liste."""
         text = obj.content or ""
         word_count = len(text.split())
+        if word_count == 0:
+            return 1
         # On ajuste la vitesse selon la densité (caractères par mot)
         # pour les contenus techniques avec des mots longs.
         avg_word_length = len(text) / word_count

--- a/apps/blog/tests/test_api.py
+++ b/apps/blog/tests/test_api.py
@@ -73,6 +73,15 @@ class TestPostListAPI:
         data = response.json()
         assert "Hello world" in data["results"][0]["plain_content"]
 
+    def test_list_with_empty_content_does_not_crash(self):
+        # Regression: PostListSerializer.get_reading_time_minutes raised
+        # ZeroDivisionError when Post.content was an empty string.
+        PostFactory(content="")
+        response = self.client.get(API_POSTS_URL)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["results"][0]["reading_time_minutes"] == 1
+
     def test_list_drafts_requires_auth(self):
         PostFactory(status="draft")
         response = self.client.get(f"{API_POSTS_URL}?status=draft")


### PR DESCRIPTION
## Description

Closes #216

Un `ZeroDivisionError` dans `PostListSerializer.get_reading_time_minutes()`
([apps/blog/serializers.py](apps/blog/serializers.py)) faisait retourner une **500**
sur `GET /api/blog/posts/` et `GET /api/blog/posts/?status=draft` dès qu'un
post avait un `content` vide (cas nominal pour un brouillon fraîchement créé
avant saisie dans l'éditeur BlockNote).

Côté utilisateur, l'enregistrement d'articles/brouillons semblait cassé :
la création (POST) et l'autosave (PATCH) fonctionnaient mais toutes les
pages listant les posts (accueil, « Mes brouillons ») plantaient, donnant
l'impression que rien n'avait été sauvegardé.

## Correctif

- `get_reading_time_minutes` retourne `1` quand `word_count == 0` (au lieu
  de calculer `len(text) / word_count` → division par zéro).
- Test de régression sur l'endpoint de liste avec un post `content=""`.

## Test plan

- [x] `pytest apps/blog` → 170 tests OK
- [x] Nouveau test `test_list_with_empty_content_does_not_crash` valide la non-régression
- [ ] Vérifier manuellement : créer un brouillon vide puis ouvrir « Mes brouillons » → plus de 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)