### PR TITLE
Refonte éditoriale : page article + harmonisation home/list/edit/contact

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>NICKORP</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,500;0,8..60,600;1,8..60,400;1,8..60,500&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body class="bg-white min-h-screen flex flex-col">
     <div id="root"></div>

--- a/frontend/src/components/blog/CommentForm.jsx
+++ b/frontend/src/components/blog/CommentForm.jsx
@@ -1,28 +1,54 @@
-import { Alert, Button, Textarea } from "@mantine/core";
+import { Alert } from "@mantine/core";
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import { api } from "../../api/client";
 import { useAuth } from "../../contexts/AuthContext";
 
-export default function CommentForm({ slug, onCommentAdded }) {
+export default function CommentForm({ slug, onCommentAdded, commentsCount = 0 }) {
   const { user } = useAuth();
   const [content, setContent] = useState("");
   const [error, setError] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [successMsg, setSuccessMsg] = useState("");
+  const [focused, setFocused] = useState(false);
+
+  const header = (
+    <div
+      className="text-editorial-dim"
+      style={{
+        fontSize: 11,
+        textTransform: "uppercase",
+        letterSpacing: 1.5,
+        fontWeight: 500,
+        marginBottom: 18,
+      }}
+    >
+      Commentaires · {commentsCount}
+    </div>
+  );
 
   if (!user) {
     return (
-      <div className="text-center py-4">
-        <p className="text-sm text-gray-600">
+      <div>
+        {header}
+        <div
+          className="text-editorial-text"
+          style={{
+            border: "1px solid #e7e5e0",
+            padding: 14,
+            background: "#fff",
+            fontSize: 13,
+            lineHeight: 1.55,
+          }}
+        >
           <Link
             to="/comptes/connexion"
-            className="text-gray-900 font-medium hover:underline"
+            className="text-editorial-ink font-medium hover:underline"
           >
             Connectez-vous
           </Link>{" "}
-          pour poster un commentaire.
-        </p>
+          pour laisser un commentaire.
+        </div>
       </div>
     );
   }
@@ -41,6 +67,7 @@ export default function CommentForm({ slug, onCommentAdded }) {
 
     if (res.ok) {
       setContent("");
+      setFocused(false);
       setSuccessMsg(
         "Votre commentaire a été soumis et est en attente de modération."
       );
@@ -51,30 +78,76 @@ export default function CommentForm({ slug, onCommentAdded }) {
     setSubmitting(false);
   };
 
+  const expanded = focused || content.length > 0;
+
   return (
     <div>
+      {header}
       {successMsg && (
-        <Alert color="green" mb="sm">
+        <Alert color="green" mb="sm" variant="light" radius={2}>
           {successMsg}
         </Alert>
       )}
-      <form onSubmit={handleSubmit}>
-        <Textarea
+      <form
+        onSubmit={handleSubmit}
+        style={{
+          border: "1px solid #e7e5e0",
+          background: "#fff",
+          padding: 14,
+        }}
+      >
+        <textarea
           value={content}
           onChange={(e) => setContent(e.target.value)}
-          rows={3}
-          placeholder="Écrivez votre commentaire..."
-          error={error || undefined}
-          mb="sm"
+          onFocus={() => setFocused(true)}
+          onBlur={() => !content && setFocused(false)}
+          placeholder="Laisser un commentaire…"
+          rows={expanded ? 3 : 1}
+          style={{
+            width: "100%",
+            border: "none",
+            outline: "none",
+            resize: "vertical",
+            fontFamily: '"Inter", system-ui, sans-serif',
+            fontSize: 13,
+            lineHeight: 1.55,
+            color: "#2a2a2a",
+            background: "transparent",
+            fontStyle: content ? "normal" : "italic",
+          }}
         />
-        <Button
-          type="submit"
-          loading={submitting}
-          color="dark"
-          size="sm"
-        >
-          Publier le commentaire
-        </Button>
+        {error && (
+          <div className="text-red-600 text-xs mt-1">{error}</div>
+        )}
+        {expanded && (
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "flex-end",
+              marginTop: 10,
+            }}
+          >
+            <button
+              type="submit"
+              disabled={submitting || !content.trim()}
+              style={{
+                fontFamily: '"Inter", system-ui, sans-serif',
+                fontSize: 12,
+                fontWeight: 500,
+                background: "#111",
+                color: "#fff",
+                border: "none",
+                padding: "6px 12px",
+                borderRadius: 3,
+                cursor: "pointer",
+                opacity: submitting || !content.trim() ? 0.5 : 1,
+                transition: "opacity 120ms ease",
+              }}
+            >
+              {submitting ? "Publication…" : "Publier"}
+            </button>
+          </div>
+        )}
       </form>
     </div>
   );

--- a/frontend/src/components/blog/CommentSection.jsx
+++ b/frontend/src/components/blog/CommentSection.jsx
@@ -1,10 +1,70 @@
-import { Avatar, Button, Group, Text, ActionIcon } from "@mantine/core";
 import { useEffect, useState } from "react";
 import { api } from "../../api/client";
-import { useAuth } from "../../contexts/AuthContext";
 
-export default function CommentSection({ comments: initialComments, slug }) {
-  const { user } = useAuth();
+function CommentAvatar({ author, size = 28 }) {
+  const initial = (
+    author.first_name?.[0] ||
+    author.email?.[0] ||
+    author.username?.[0] ||
+    "?"
+  ).toUpperCase();
+
+  if (author.avatar) {
+    return (
+      <img
+        src={author.avatar}
+        alt=""
+        style={{
+          width: size,
+          height: size,
+          borderRadius: "50%",
+          objectFit: "cover",
+          flexShrink: 0,
+        }}
+      />
+    );
+  }
+
+  return (
+    <div
+      style={{
+        width: size,
+        height: size,
+        borderRadius: "50%",
+        background: "#ece8dd",
+        color: "#1f1f1f",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        fontSize: Math.round(size * 0.4),
+        fontWeight: 600,
+        flexShrink: 0,
+      }}
+    >
+      {initial}
+    </div>
+  );
+}
+
+function formatRelative(dateStr) {
+  const date = new Date(dateStr);
+  const diffMs = Date.now() - date.getTime();
+  const diffMin = Math.round(diffMs / 60000);
+  const diffH = Math.round(diffMs / 3600000);
+  const diffD = Math.round(diffMs / 86400000);
+  if (diffMin < 1) return "à l'instant";
+  if (diffMin < 60) return `il y a ${diffMin} min`;
+  if (diffH < 24) return `il y a ${diffH} heure${diffH > 1 ? "s" : ""}`;
+  if (diffD === 1) return "hier";
+  if (diffD < 7) return `il y a ${diffD} jours`;
+  return date.toLocaleDateString("fr-FR", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+export default function CommentSection({ comments: initialComments, slug: _slug }) {
   const [comments, setComments] = useState(initialComments || []);
   const [visibleCount, setVisibleCount] = useState(10);
 
@@ -21,103 +81,121 @@ export default function CommentSection({ comments: initialComments, slug }) {
 
   const visibleComments = comments.slice(0, visibleCount);
 
+  if (comments.length === 0) {
+    return (
+      <div
+        className="text-editorial-dim"
+        style={{
+          fontSize: 13,
+          fontStyle: "italic",
+          lineHeight: 1.55,
+        }}
+      >
+        Aucun commentaire pour le moment.
+      </div>
+    );
+  }
+
   return (
     <div>
-      <Text size="sm" c="dimmed" mb="md">
-        {comments.length} commentaire{comments.length !== 1 ? "s" : ""}
-      </Text>
+      <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
+        {visibleComments.map((comment) => {
+          const authorName =
+            comment.author.first_name && comment.author.last_name
+              ? `${comment.author.first_name} ${comment.author.last_name}`
+              : comment.author.username;
 
-      {comments.length > 0 ? (
-        <>
-          <div className="space-y-4">
-            {visibleComments.map((comment) => {
-              const authorName =
-                comment.author.first_name && comment.author.last_name
-                  ? `${comment.author.first_name} ${comment.author.last_name}`
-                  : comment.author.username;
-
-              const initial = (
-                comment.author.first_name?.[0] ||
-                comment.author.email?.[0] ||
-                comment.author.username?.[0] ||
-                "?"
-              ).toUpperCase();
-
-              return (
-                <div key={comment.id}>
-                  <Group>
-                    <Avatar
-                      src={comment.author.avatar}
-                      alt={authorName}
-                      radius="xl"
-                      color="gray"
-                    >
-                      {initial}
-                    </Avatar>
-                    <div style={{ flex: 1 }}>
-                      <Group justify="space-between" wrap="nowrap">
-                        <div>
-                          <Text size="sm" fw={500}>
-                            {authorName}
-                          </Text>
-                          <Text size="xs" c="dimmed">
-                            {new Date(comment.created_at).toLocaleString(
-                              "fr-FR"
-                            )}
-                          </Text>
-                        </div>
-                        {comment.is_owner && (
-                          <ActionIcon
-                            variant="subtle"
-                            color="gray"
-                            size="sm"
-                            onClick={() => handleDelete(comment.id)}
-                            title="Supprimer"
-                          >
-                            <svg
-                              xmlns="http://www.w3.org/2000/svg"
-                              fill="none"
-                              viewBox="0 0 24 24"
-                              strokeWidth={1.5}
-                              stroke="currentColor"
-                              className="w-4 h-4"
-                            >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                d="M6 18 18 6M6 6l12 12"
-                              />
-                            </svg>
-                          </ActionIcon>
-                        )}
-                      </Group>
-                    </div>
-                  </Group>
-                  <Text pl={54} pt="sm" size="sm">
-                    {comment.content}
-                  </Text>
-                </div>
-              );
-            })}
-          </div>
-
-          {visibleCount < comments.length && (
-            <div className="mt-4 text-center">
-              <Button
-                variant="subtle"
-                color="gray"
-                size="sm"
-                onClick={() => setVisibleCount((prev) => prev + 10)}
+          return (
+            <div key={comment.id}>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 10,
+                  marginBottom: 6,
+                }}
               >
-                Voir les 10 commentaires suivants
-              </Button>
+                <CommentAvatar author={comment.author} size={28} />
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div
+                    style={{
+                      fontSize: 13,
+                      fontWeight: 500,
+                      color: "#1f1f1f",
+                    }}
+                  >
+                    {authorName}
+                  </div>
+                  <div style={{ fontSize: 11, color: "#6b6b6b" }}>
+                    {formatRelative(comment.created_at)}
+                  </div>
+                </div>
+                {comment.is_owner && (
+                  <button
+                    type="button"
+                    onClick={() => handleDelete(comment.id)}
+                    title="Supprimer"
+                    aria-label="Supprimer le commentaire"
+                    style={{
+                      border: "none",
+                      background: "transparent",
+                      color: "#9a9a9a",
+                      cursor: "pointer",
+                      padding: 4,
+                      display: "inline-flex",
+                    }}
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      strokeWidth={1.5}
+                      stroke="currentColor"
+                      className="w-4 h-4"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M6 18 18 6M6 6l12 12"
+                      />
+                    </svg>
+                  </button>
+                )}
+              </div>
+              <div
+                style={{
+                  fontSize: 14,
+                  lineHeight: 1.55,
+                  color: "#2a2a2a",
+                  paddingLeft: 38,
+                }}
+              >
+                {comment.content}
+              </div>
             </div>
-          )}
-        </>
-      ) : (
-        <Text size="sm" c="dimmed">
-          Aucun commentaire pour le moment.
-        </Text>
+          );
+        })}
+      </div>
+
+      {visibleCount < comments.length && (
+        <div style={{ marginTop: 20, textAlign: "center" }}>
+          <button
+            type="button"
+            onClick={() => setVisibleCount((prev) => prev + 10)}
+            style={{
+              fontFamily: '"Inter", system-ui, sans-serif',
+              fontSize: 12,
+              color: "#6b6b6b",
+              background: "transparent",
+              border: "none",
+              cursor: "pointer",
+              textDecoration: "underline",
+              textUnderlineOffset: 3,
+            }}
+          >
+            Voir les 10 commentaires suivants
+          </button>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/blog/FeaturedPosts.jsx
+++ b/frontend/src/components/blog/FeaturedPosts.jsx
@@ -1,6 +1,47 @@
-import { Badge } from "@mantine/core";
 import { Link } from "react-router-dom";
-import Avatar from "../ui/Avatar";
+
+function FeaturedAvatar({ user, size = 22 }) {
+  const initial = (
+    user.first_name?.[0] ||
+    user.email?.[0] ||
+    user.username?.[0] ||
+    "?"
+  ).toUpperCase();
+  if (user.avatar) {
+    return (
+      <img
+        src={user.avatar}
+        alt=""
+        style={{
+          width: size,
+          height: size,
+          borderRadius: "50%",
+          objectFit: "cover",
+          flexShrink: 0,
+        }}
+      />
+    );
+  }
+  return (
+    <div
+      style={{
+        width: size,
+        height: size,
+        borderRadius: "50%",
+        background: "#ddd6c8",
+        color: "#1f1f1f",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        fontSize: Math.round(size * 0.42),
+        fontWeight: 600,
+        flexShrink: 0,
+      }}
+    >
+      {initial}
+    </div>
+  );
+}
 
 function FeaturedCard({ post }) {
   const authorName =
@@ -9,52 +50,64 @@ function FeaturedCard({ post }) {
       : post.author.username;
   const date = new Date(
     post.published_at || post.created_at
-  ).toLocaleDateString("fr-FR");
+  ).toLocaleDateString("fr-FR", { day: "numeric", month: "short" });
   const excerpt = post.plain_content
-    ? post.plain_content.split(" ").slice(0, 30).join(" ") +
-      (post.plain_content.split(" ").length > 30 ? "..." : "")
+    ? post.plain_content.split(" ").slice(0, 24).join(" ") +
+      (post.plain_content.split(" ").length > 24 ? "…" : "")
     : "";
+  const primaryTopic =
+    post.tags && post.tags.length > 0 ? post.tags[0].name.toUpperCase() : null;
 
   return (
-    <article className="flex flex-col overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm hover:shadow-md transition-shadow">
+    <article className="flex flex-col bg-white border border-editorial-rule h-full">
       <Link to={`/articles/${post.slug}`} className="block">
         {post.cover_image ? (
           <img
             src={post.cover_image}
             alt={post.title}
-            className="w-full h-56 object-cover"
+            className="w-full h-44 object-cover"
           />
         ) : (
-          <div className="w-full h-56 bg-gradient-to-br from-blue-50 to-gray-100" />
+          <div className="w-full h-44 bg-editorial-paper flex items-center justify-center">
+            <span
+              className="font-serif italic text-editorial-dim2"
+              style={{ fontSize: 22 }}
+            >
+              N
+            </span>
+          </div>
         )}
       </Link>
       <div className="flex flex-1 flex-col p-5">
-        <h3 className="text-lg font-semibold text-gray-900">
+        {primaryTopic && (
+          <p
+            className="font-sans text-editorial-accent font-semibold mb-2"
+            style={{
+              fontSize: 10,
+              letterSpacing: 1.6,
+              textTransform: "uppercase",
+            }}
+          >
+            {primaryTopic}
+          </p>
+        )}
+        <h3 className="font-serif text-editorial-ink leading-tight tracking-tight text-lg">
           <Link
             to={`/articles/${post.slug}`}
-            className="hover:underline"
+            className="hover:text-editorial-ink2"
           >
             {post.title}
           </Link>
         </h3>
-        {post.tags && post.tags.length > 0 && (
-          <div className="flex flex-wrap gap-1 mt-1">
-            {post.tags.map((tag) => (
-              <Badge key={tag.id} size="xs" variant="light" color="blue">
-                {tag.name}
-              </Badge>
-            ))}
-          </div>
-        )}
         {excerpt && (
-          <p className="text-sm text-gray-600 mt-3 leading-relaxed flex-1">
+          <p className="font-serif text-sm text-editorial-text mt-2 leading-relaxed flex-1">
             {excerpt}
           </p>
         )}
         <div className="flex items-center gap-2 mt-4">
-          <Avatar user={post.author} size="sm" />
-          <p className="text-xs text-gray-500">
-            {authorName} &mdash; {date}
+          <FeaturedAvatar user={post.author} size={22} />
+          <p className="font-sans text-[11px] text-editorial-dim">
+            {authorName} <span className="text-editorial-dim2">·</span> {date}
           </p>
         </div>
       </div>
@@ -65,11 +118,21 @@ function FeaturedCard({ post }) {
 export default function FeaturedPosts({ posts }) {
   if (!posts || posts.length === 0) return null;
   return (
-    <section className="mb-10">
-      <h2 className="text-xl font-semibold text-gray-900 mb-4">
-        À la une
-      </h2>
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+    <section className="mb-12">
+      <div className="flex items-baseline gap-3 mb-5">
+        <h2
+          className="font-sans text-editorial-accent font-semibold"
+          style={{
+            fontSize: 11,
+            letterSpacing: 2,
+            textTransform: "uppercase",
+          }}
+        >
+          À la une
+        </h2>
+        <span className="flex-1 h-px bg-editorial-rule" />
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
         {posts.map((post) => (
           <FeaturedCard key={post.id} post={post} />
         ))}

--- a/frontend/src/components/blog/PostCard.jsx
+++ b/frontend/src/components/blog/PostCard.jsx
@@ -1,16 +1,59 @@
-import { Link } from "react-router-dom";
-import { Badge, Menu } from "@mantine/core";
+import { Menu } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import { useState } from "react";
+import { Link } from "react-router-dom";
 import { api } from "../../api/client";
 import { useAuth } from "../../contexts/AuthContext";
-import Avatar from "../ui/Avatar";
+
+function CardAvatar({ user, size = 24 }) {
+  const initial = (
+    user.first_name?.[0] ||
+    user.email?.[0] ||
+    user.username?.[0] ||
+    "?"
+  ).toUpperCase();
+  if (user.avatar) {
+    return (
+      <img
+        src={user.avatar}
+        alt=""
+        style={{
+          width: size,
+          height: size,
+          borderRadius: "50%",
+          objectFit: "cover",
+          flexShrink: 0,
+        }}
+      />
+    );
+  }
+  return (
+    <div
+      style={{
+        width: size,
+        height: size,
+        borderRadius: "50%",
+        background: "#ddd6c8",
+        color: "#1f1f1f",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        fontSize: Math.round(size * 0.42),
+        fontWeight: 600,
+        flexShrink: 0,
+      }}
+    >
+      {initial}
+    </div>
+  );
+}
 
 export default function PostCard({ post: initialPost, onChange }) {
   const { user } = useAuth();
   const [post, setPost] = useState(initialPost);
   const [pinToggling, setPinToggling] = useState(false);
-  const canEdit = user && user.is_superuser && post.author && user.id === post.author.id;
+  const canEdit =
+    user && user.is_superuser && post.author && user.id === post.author.id;
   const canPin = canEdit && post.status === "published";
 
   const handleTogglePin = async () => {
@@ -40,41 +83,169 @@ export default function PostCard({ post: initialPost, onChange }) {
       ? `${post.author.first_name} ${post.author.last_name}`
       : post.author.username;
 
-  const date = new Date(post.created_at).toLocaleDateString("fr-FR");
+  const date = new Date(
+    post.published_at || post.created_at
+  ).toLocaleDateString("fr-FR", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+
+  const primaryTopic =
+    post.tags && post.tags.length > 0
+      ? post.tags
+          .slice(0, 3)
+          .map((t) => t.name)
+          .join(" · ")
+          .toUpperCase()
+      : null;
+
+  const excerpt = post.plain_content
+    ? post.plain_content.split(" ").slice(0, 38).join(" ") +
+      (post.plain_content.split(" ").length > 38 ? "…" : "")
+    : "";
 
   return (
-    <article className="card">
-      {post.cover_image && (
-        <Link to={`/articles/${post.slug}`}>
-          <img
-            src={post.cover_image}
-            alt={post.title}
-            className="w-full h-48 object-cover rounded-t-lg -mt-6 mb-4"
-          />
-        </Link>
-      )}
-      <div className="flex items-start justify-between">
-        <div>
-          <h2 className="text-xl font-semibold text-gray-900">
+    <article className="card flex gap-6">
+      <div className="flex-1 min-w-0">
+        {primaryTopic && (
+          <p
+            className="font-sans text-editorial-accent font-semibold mb-2"
+            style={{
+              fontSize: 11,
+              letterSpacing: 1.6,
+              textTransform: "uppercase",
+            }}
+          >
+            {primaryTopic}
+          </p>
+        )}
+
+        <div className="flex items-start justify-between gap-3">
+          <h2 className="font-serif text-editorial-ink text-2xl leading-tight tracking-tight">
             <Link
               to={`/articles/${post.slug}`}
-              className="hover:underline"
+              className="hover:text-editorial-ink2"
             >
               {post.title}
             </Link>
           </h2>
-          {post.tags && post.tags.length > 0 && (
-            <div className="flex flex-wrap gap-1 mt-1">
-              {post.tags.map((tag) => (
-                <Badge key={tag.id} size="xs" variant="light" color="blue">
-                  {tag.name}
-                </Badge>
-              ))}
-            </div>
+          {canEdit && (
+            <Menu position="bottom-end" shadow="md" width={200}>
+              <Menu.Target>
+                <button
+                  className="text-editorial-dim2 hover:text-editorial-ink transition-colors shrink-0 mt-1"
+                  title="Actions"
+                  aria-label="Actions"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    strokeWidth={1.5}
+                    stroke="currentColor"
+                    className="size-5"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M12 6.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5ZM12 12.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5ZM12 18.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5Z"
+                    />
+                  </svg>
+                </button>
+              </Menu.Target>
+              <Menu.Dropdown>
+                <Menu.Item
+                  component={Link}
+                  to={`/articles/${post.slug}/modifier`}
+                  leftSection={
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      strokeWidth={1.5}
+                      stroke="currentColor"
+                      className="size-5"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10"
+                      />
+                    </svg>
+                  }
+                >
+                  Modifier
+                </Menu.Item>
+                {canPin && (
+                  <Menu.Item
+                    onClick={handleTogglePin}
+                    disabled={pinToggling}
+                    leftSection={
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill={post.is_pinned ? "currentColor" : "none"}
+                        viewBox="0 0 24 24"
+                        strokeWidth={1.5}
+                        stroke="currentColor"
+                        className="size-5"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M9 4.5v4.5l-3 3v2.25h12V12l-3-3V4.5m-6 9v6m3-10.5h.008v.008H12V7.5Z"
+                        />
+                      </svg>
+                    }
+                  >
+                    {post.is_pinned ? "Désépingler" : "Épingler à la une"}
+                  </Menu.Item>
+                )}
+                <Menu.Item
+                  component={Link}
+                  to={`/articles/${post.slug}/supprimer`}
+                  color="red"
+                  leftSection={
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      strokeWidth={1.5}
+                      stroke="currentColor"
+                      className="size-5"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"
+                      />
+                    </svg>
+                  }
+                >
+                  Supprimer
+                </Menu.Item>
+              </Menu.Dropdown>
+            </Menu>
           )}
+        </div>
+
+        {excerpt && (
+          <p className="font-serif text-editorial-text mt-3 leading-relaxed text-[17px]">
+            {excerpt}
+          </p>
+        )}
+
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2 mt-4">
+          <div className="flex items-center gap-2">
+            <CardAvatar user={post.author} size={24} />
+            <p className="font-sans text-xs text-editorial-dim">
+              {authorName}{" "}
+              <span className="text-editorial-dim2">·</span> {date}
+            </p>
+          </div>
           {post.is_pinned && (
             <span
-              className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 mt-1"
+              className="inline-flex items-center gap-1 text-[10px] tracking-[1.4px] uppercase font-semibold text-editorial-accent"
               title="Article épinglé à la une"
             >
               <svg
@@ -96,138 +267,27 @@ export default function PostCard({ post: initialPost, onChange }) {
           )}
           {canEdit && post.has_draft && post.status === "published" && (
             <span
-              className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700 mt-1"
+              className="inline-flex items-center gap-1 text-[10px] tracking-[1.4px] uppercase font-semibold text-editorial-accent italic"
               title="Brouillon en cours"
             >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                strokeWidth={1.5}
-                stroke="currentColor"
-                className="size-3"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Z"
-                />
-              </svg>
               Brouillon en cours
             </span>
           )}
-          <div className="flex items-center gap-2 mt-1">
-            <Avatar user={post.author} size="sm" />
-            <p className="text-sm text-gray-500">
-              {authorName} &mdash; {date}
-            </p>
-          </div>
         </div>
-        {canEdit && (
-          <Menu position="bottom-end" shadow="md" width={200}>
-            <Menu.Target>
-              <button
-                className="text-gray-400 hover:text-black transition-colors ml-4 shrink-0"
-                title="Actions"
-                aria-label="Actions"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  strokeWidth={1.5}
-                  stroke="currentColor"
-                  className="size-5"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M12 6.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5ZM12 12.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5ZM12 18.75a.75.75 0 1 1 0-1.5.75.75 0 0 1 0 1.5Z"
-                  />
-                </svg>
-              </button>
-            </Menu.Target>
-            <Menu.Dropdown>
-              <Menu.Item
-                component={Link}
-                to={`/articles/${post.slug}/modifier`}
-                leftSection={
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    strokeWidth={1.5}
-                    stroke="currentColor"
-                    className="size-5"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10"
-                    />
-                  </svg>
-                }
-              >
-                Modifier
-              </Menu.Item>
-              {canPin && (
-                <Menu.Item
-                  onClick={handleTogglePin}
-                  disabled={pinToggling}
-                  leftSection={
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      fill={post.is_pinned ? "currentColor" : "none"}
-                      viewBox="0 0 24 24"
-                      strokeWidth={1.5}
-                      stroke="currentColor"
-                      className="size-5"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M9 4.5v4.5l-3 3v2.25h12V12l-3-3V4.5m-6 9v6m3-10.5h.008v.008H12V7.5Z"
-                      />
-                    </svg>
-                  }
-                >
-                  {post.is_pinned ? "Désépingler" : "Épingler à la une"}
-                </Menu.Item>
-              )}
-              <Menu.Item
-                component={Link}
-                to={`/articles/${post.slug}/supprimer`}
-                color="red"
-                leftSection={
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    strokeWidth={1.5}
-                    stroke="currentColor"
-                    className="size-5"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"
-                    />
-                  </svg>
-                }
-              >
-                Supprimer
-              </Menu.Item>
-            </Menu.Dropdown>
-          </Menu>
-        )}
       </div>
-      <p className="text-gray-600 mt-3 leading-relaxed">
-        {post.plain_content
-          ? post.plain_content.split(" ").slice(0, 50).join(" ") +
-            (post.plain_content.split(" ").length > 50 ? "..." : "")
-          : ""}
-      </p>
 
+      {post.cover_image && (
+        <Link
+          to={`/articles/${post.slug}`}
+          className="hidden sm:block shrink-0 w-40 h-28 overflow-hidden"
+        >
+          <img
+            src={post.cover_image}
+            alt={post.title}
+            className="w-full h-full object-cover"
+          />
+        </Link>
+      )}
     </article>
   );
 }

--- a/frontend/src/components/blog/PostDetail.jsx
+++ b/frontend/src/components/blog/PostDetail.jsx
@@ -1,7 +1,7 @@
 import "@blocknote/core/fonts/inter.css";
 import "@blocknote/mantine/style.css";
 import { useCreateBlockNote } from "@blocknote/react";
-import { Alert, Badge } from "@mantine/core";
+import { Alert } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import DOMPurify from "dompurify";
 import { useEffect, useMemo, useState } from "react";
@@ -9,7 +9,6 @@ import { Helmet } from "react-helmet-async";
 import { Link, useParams } from "react-router-dom";
 import { api } from "../../api/client";
 import { useAuth } from "../../contexts/AuthContext";
-import Avatar from "../ui/Avatar";
 import CommentForm from "./CommentForm";
 import CommentSection from "./CommentSection";
 
@@ -33,21 +32,229 @@ function BlockNoteRenderer({ content }) {
 
   useEffect(() => {
     if (editor && validBlocks) {
-      editor.blocksToFullHTML(editor.document).then((rawHtml) => {
-        setHtml(DOMPurify.sanitize(rawHtml));
-      }).catch(() => {});
+      editor
+        .blocksToFullHTML(editor.document)
+        .then((rawHtml) => {
+          setHtml(DOMPurify.sanitize(rawHtml));
+        })
+        .catch(() => {});
     }
   }, [editor, validBlocks]);
 
   if (!validBlocks) {
-    return <div className="whitespace-pre-line">{content}</div>;
+    return (
+      <div className="article-prose whitespace-pre-line">{content}</div>
+    );
   }
 
   return (
     <div
-      className="text-gray-700 leading-relaxed"
+      className="article-prose"
       dangerouslySetInnerHTML={{ __html: html }}
     />
+  );
+}
+
+function AuthorAvatar({ user, size = 36 }) {
+  const initial = (
+    user.first_name?.[0] ||
+    user.email?.[0] ||
+    user.username?.[0] ||
+    "?"
+  ).toUpperCase();
+
+  if (user.avatar) {
+    return (
+      <img
+        src={user.avatar}
+        alt=""
+        style={{
+          width: size,
+          height: size,
+          borderRadius: "50%",
+          objectFit: "cover",
+          flexShrink: 0,
+        }}
+      />
+    );
+  }
+
+  return (
+    <div
+      style={{
+        width: size,
+        height: size,
+        borderRadius: "50%",
+        background: "#ddd6c8",
+        color: "#1f1f1f",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        fontSize: Math.round(size * 0.36),
+        fontWeight: 600,
+        flexShrink: 0,
+      }}
+    >
+      {initial}
+    </div>
+  );
+}
+
+function OwnerIcon({ d, filled = false }) {
+  return (
+    <svg
+      width="13"
+      height="13"
+      viewBox="0 0 24 24"
+      fill={filled ? "currentColor" : "none"}
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d={d} />
+    </svg>
+  );
+}
+
+function OwnerActions({
+  post,
+  publishing,
+  onPublish,
+  pinToggling,
+  onTogglePin,
+  hasVersions,
+  hasDraftChanges,
+}) {
+  const base = {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 6,
+    fontFamily: '"Inter", system-ui, sans-serif',
+    fontSize: 12,
+    fontWeight: 500,
+    padding: "6px 10px",
+    borderRadius: 3,
+    cursor: "pointer",
+    whiteSpace: "nowrap",
+    textDecoration: "none",
+    transition: "background-color 120ms ease, border-color 120ms ease",
+  };
+  const neutral = {
+    ...base,
+    border: "1px solid #e7e5e0",
+    background: "#fff",
+    color: "#2a2a2a",
+  };
+  const primary = {
+    ...base,
+    border: "1px solid #111",
+    background: "#111",
+    color: "#fff",
+  };
+  const canPublishDraft = post.status === "draft";
+  const canPublishChanges = post.status === "published" && post.has_draft;
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: 6,
+        flexWrap: "wrap",
+        alignItems: "center",
+        padding: "10px 0",
+        borderTop: "1px solid #e7e5e0",
+        borderBottom: "1px solid #e7e5e0",
+        margin: "28px 0",
+      }}
+    >
+      <span
+        style={{
+          fontFamily: '"Inter", system-ui, sans-serif',
+          fontSize: 11,
+          color: "#6b6b6b",
+          textTransform: "uppercase",
+          letterSpacing: 1,
+          fontWeight: 500,
+          alignSelf: "center",
+          marginRight: 8,
+        }}
+      >
+        Auteur
+      </span>
+
+      <Link to={`/articles/${post.slug}/modifier`} style={neutral} title="Modifier">
+        <OwnerIcon d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Z" />
+        <span>Modifier</span>
+      </Link>
+
+      {(canPublishDraft || canPublishChanges) && (
+        <button
+          type="button"
+          onClick={onPublish}
+          disabled={publishing}
+          style={{ ...primary, opacity: publishing ? 0.6 : 1 }}
+          title={canPublishChanges ? "Publier les modifications" : "Publier"}
+        >
+          <OwnerIcon d="M12 19.5v-15m0 0-6.75 6.75M12 4.5l6.75 6.75" />
+          <span>
+            {publishing
+              ? "Publication…"
+              : canPublishChanges
+                ? "Publier les modifications"
+                : "Publier"}
+          </span>
+        </button>
+      )}
+
+      {post.status === "published" && (
+        <button
+          type="button"
+          onClick={onTogglePin}
+          disabled={pinToggling}
+          style={{ ...neutral, opacity: pinToggling ? 0.6 : 1 }}
+          title={post.is_pinned ? "Désépingler" : "Épingler à la une"}
+        >
+          <OwnerIcon
+            d="M9 4.5v4.5l-3 3v2.25h12V12l-3-3V4.5m-6 9v6"
+            filled={post.is_pinned}
+          />
+          <span>{post.is_pinned ? "Désépingler" : "Épingler"}</span>
+        </button>
+      )}
+
+      {hasVersions && (
+        <Link to={`/articles/${post.slug}/versions`} style={neutral} title="Versions">
+          <OwnerIcon d="M12 6v6h4.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+          <span>Versions</span>
+        </Link>
+      )}
+
+      <Link
+        to={`/articles/${post.slug}/supprimer`}
+        style={neutral}
+        title="Supprimer"
+      >
+        <OwnerIcon d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0c.342.052.682.107 1.022.166m-16.5-.165c.34-.059.68-.114 1.022-.165m14.456 0a48.108 48.108 0 0 0-3.478-.397M5.794 5.625a48.11 48.11 0 0 1 3.478-.397M15.272 5.228v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916" />
+        <span>Supprimer</span>
+      </Link>
+
+      <div style={{ flex: 1 }} />
+
+      {hasDraftChanges && (
+        <span
+          style={{
+            fontFamily: '"Inter", system-ui, sans-serif',
+            fontSize: 11,
+            color: "#b54b1a",
+            alignSelf: "center",
+            fontStyle: "italic",
+          }}
+        >
+          Modifications non publiées
+        </span>
+      )}
+    </div>
   );
 }
 
@@ -69,9 +276,7 @@ export default function PostDetail() {
     if (res.ok) {
       setPost(res.data);
     } else {
-      setPublishError(
-        res.errors?.error || "Erreur lors de la publication."
-      );
+      setPublishError(res.errors?.error || "Erreur lors de la publication.");
     }
     setPublishing(false);
   };
@@ -120,7 +325,7 @@ export default function PostDetail() {
   if (loading) {
     return (
       <div className="max-w-3xl mx-auto px-4 py-12">
-        <p className="text-gray-500 text-center">Chargement...</p>
+        <p className="text-editorial-dim text-center">Chargement…</p>
       </div>
     );
   }
@@ -128,7 +333,7 @@ export default function PostDetail() {
   if (!post) {
     return (
       <div className="max-w-3xl mx-auto px-4 py-12">
-        <p className="text-gray-500 text-center">Article introuvable.</p>
+        <p className="text-editorial-dim text-center">Article introuvable.</p>
       </div>
     );
   }
@@ -143,238 +348,179 @@ export default function PostDetail() {
       ? post.draft_title
       : post.title;
   const displayContent =
-    post.is_owner && post.status === "draft" && !post.content && post.draft_content
+    post.is_owner &&
+    post.status === "draft" &&
+    !post.content &&
+    post.draft_content
       ? post.draft_content
       : post.content;
 
-  // Sujet principal (utilisé pour le fil d'Ariane et le partage social).
   const primaryTopic =
-    post.tags && post.tags.length > 0 ? post.tags[0].name.toUpperCase() : null;
+    post.tags && post.tags.length > 0 ? post.tags[0].name : null;
+  const otherTopics =
+    post.tags && post.tags.length > 1
+      ? post.tags.slice(1).map((t) => t.name).join(" · ")
+      : null;
+  const topicLine = [primaryTopic, otherTopics].filter(Boolean).join(" · ");
+
+  const publishedDate = post.published_at || post.created_at;
+  const readingMinutes = post.reading_time_minutes;
+  const isOwnerSuperuser = post.is_owner && user?.is_superuser;
+  const hasDraftChanges = post.status === "published" && post.has_draft;
 
   return (
-    <div className="max-w-6xl mx-auto px-4 py-12">
+    <div className="bg-white">
       <Helmet>
         <title>{displayTitle}</title>
-        <meta name="description" content={primaryTopic ? `${primaryTopic} — ${displayTitle}` : displayTitle} />
+        <meta
+          name="description"
+          content={
+            primaryTopic
+              ? `${primaryTopic.toUpperCase()} — ${displayTitle}`
+              : displayTitle
+          }
+        />
       </Helmet>
 
-      <div className="flex flex-col lg:flex-row lg:gap-8">
-        {/* Article — colonne gauche */}
-        <div className="flex-1 min-w-0">
-          <article>
-            {primaryTopic && (
-              <p className="text-xs uppercase tracking-wide text-gray-500 mb-1">
-                {primaryTopic}
+      <div className="max-w-[1200px] mx-auto px-5 sm:px-10 py-12 lg:py-16">
+        <div className="lg:grid lg:grid-cols-[minmax(0,1fr)_320px] lg:gap-16">
+          <article className="min-w-0">
+            {topicLine && (
+              <p
+                className="font-sans text-editorial-accent font-semibold mb-3"
+                style={{
+                  fontSize: 11,
+                  letterSpacing: 2,
+                  textTransform: "uppercase",
+                }}
+              >
+                {topicLine}
               </p>
             )}
-            <h1 className="text-3xl font-bold text-gray-900 mb-2">{displayTitle}</h1>
-            {post.tags && post.tags.length > 0 && (
-              <div className="flex flex-wrap gap-1 mb-4">
-                {post.tags.map((tag) => (
-                  <Badge key={tag.id} size="sm" variant="light" color="blue">
-                    {tag.name}
-                  </Badge>
-                ))}
+
+            <h1
+              className="font-serif text-editorial-ink"
+              style={{
+                fontSize: "clamp(32px, 4.6vw, 54px)",
+                lineHeight: 1.05,
+                fontWeight: 600,
+                letterSpacing: "-0.02em",
+                margin: "0 0 20px",
+                maxWidth: 720,
+              }}
+            >
+              {displayTitle}
+            </h1>
+
+            <div
+              className="flex items-center gap-3"
+              style={{
+                fontFamily: '"Inter", system-ui, sans-serif',
+                paddingBottom: 16,
+              }}
+            >
+              <AuthorAvatar user={post.author} size={36} />
+              <div>
+                <div
+                  style={{
+                    fontSize: 13,
+                    fontWeight: 500,
+                    color: "#1f1f1f",
+                  }}
+                >
+                  {authorName}
+                </div>
+                <div style={{ fontSize: 12, color: "#6b6b6b" }}>
+                  {new Date(publishedDate).toLocaleDateString("fr-FR", {
+                    day: "numeric",
+                    month: "long",
+                    year: "numeric",
+                  })}
+                  {readingMinutes ? ` · ${readingMinutes} min de lecture` : ""}
+                </div>
               </div>
+            </div>
+
+            {isOwnerSuperuser && (
+              <OwnerActions
+                post={post}
+                publishing={publishing}
+                onPublish={handlePublish}
+                pinToggling={pinToggling}
+                onTogglePin={handleTogglePin}
+                hasVersions={hasVersions}
+                hasDraftChanges={hasDraftChanges}
+              />
             )}
-            {post.is_owner && user?.is_superuser && (
-              <div className="flex flex-wrap items-center gap-2 mb-4">
+
+            {isOwnerSuperuser && hasDraftChanges && (
+              <Alert color="blue" className="mb-6">
+                Cet article a des modifications non publiées.{" "}
                 <Link
                   to={`/articles/${post.slug}/modifier`}
-                  className="inline-flex items-center gap-1 rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
-                  title="Modifier"
+                  className="underline font-medium"
                 >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    strokeWidth={1.5}
-                    stroke="currentColor"
-                    className="size-4"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10"
-                    />
-                  </svg>
-                  Modifier
+                  Voir les modifications
                 </Link>
-                <Link
-                  to={`/articles/${post.slug}/supprimer`}
-                  className="inline-flex items-center gap-1 rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
-                  title="Supprimer"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    strokeWidth={1.5}
-                    stroke="currentColor"
-                    className="size-4"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"
-                    />
-                  </svg>
-                  Supprimer
-                </Link>
-                {(post.status === "draft" ||
-                  (post.status === "published" && post.has_draft)) && (
-                  <button
-                    onClick={handlePublish}
-                    disabled={publishing}
-                    className="inline-flex items-center gap-1 rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors disabled:opacity-50"
-                    title={
-                      post.status === "published"
-                        ? "Publier les modifications"
-                        : "Publier"
-                    }
-                  >
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      strokeWidth={1.5}
-                      stroke="currentColor"
-                      className="size-4"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M12 19.5v-15m0 0l-6.75 6.75M12 4.5l6.75 6.75"
-                      />
-                    </svg>
-                    {publishing
-                      ? "Publication..."
-                      : post.status === "published"
-                        ? "Publier les modifications"
-                        : "Publier"}
-                  </button>
-                )}
-                {post.status === "published" && (
-                  <button
-                    onClick={handleTogglePin}
-                    disabled={pinToggling}
-                    className="inline-flex items-center gap-1 rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors disabled:opacity-50"
-                    title={
-                      post.is_pinned ? "Désépingler" : "Épingler à la une"
-                    }
-                  >
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      fill={post.is_pinned ? "currentColor" : "none"}
-                      viewBox="0 0 24 24"
-                      strokeWidth={1.5}
-                      stroke="currentColor"
-                      className="size-4"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M9 4.5v4.5l-3 3v2.25h12V12l-3-3V4.5m-6 9v6m3-10.5h.008v.008H12V7.5Z"
-                      />
-                    </svg>
-                    {post.is_pinned ? "Désépingler" : "Épingler à la une"}
-                  </button>
-                )}
-                {hasVersions && (
-                  <Link
-                    to={`/articles/${post.slug}/versions`}
-                    className="inline-flex items-center gap-1 rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
-                    title="Historique des versions"
-                  >
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      strokeWidth={1.5}
-                      stroke="currentColor"
-                      className="size-4"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
-                      />
-                    </svg>
-                    Versions
-                  </Link>
-                )}
-              </div>
+              </Alert>
             )}
-
-            {post.is_owner &&
-              user?.is_superuser &&
-              post.status === "published" &&
-              post.has_draft && (
-                <Alert color="blue" className="mb-4">
-                  Cet article a des modifications non publiées.{" "}
-                  <Link
-                    to={`/articles/${post.slug}/modifier`}
-                    className="underline font-medium"
-                  >
-                    Voir les modifications
-                  </Link>
-                </Alert>
-              )}
 
             {publishError && (
-              <p className="text-red-600 text-sm mt-2">{publishError}</p>
+              <p className="text-red-600 text-sm mb-4">{publishError}</p>
             )}
-
-            <div className="flex items-center gap-2 mb-8">
-              <Avatar user={post.author} size="md" />
-              <p className="text-sm text-gray-500">
-                {authorName} &mdash;{" "}
-                {new Date(post.created_at).toLocaleDateString("fr-FR")}
-              </p>
-            </div>
 
             {post.cover_image && (
               <img
                 src={post.cover_image}
                 alt={displayTitle}
-                className="w-full h-auto rounded-lg mb-8 object-cover"
-                style={{ maxHeight: "400px" }}
+                className="w-full h-auto object-cover mb-10"
+                style={{ maxHeight: 480 }}
               />
             )}
 
             <BlockNoteRenderer content={displayContent} />
+
+            <div
+              className="mt-14 pt-6"
+              style={{
+                borderTop: "1px solid #e7e5e0",
+                fontFamily: '"Inter", system-ui, sans-serif',
+              }}
+            >
+              <Link
+                to="/"
+                className="text-editorial-dim hover:text-editorial-ink transition-colors"
+                style={{ fontSize: 13 }}
+              >
+                ← Retour aux articles
+              </Link>
+            </div>
           </article>
 
-          <div className="mt-10">
-            <Link
-              to="/"
-              className="text-sm text-gray-500 hover:text-black transition-colors"
+          {post.status !== "draft" && (
+            <aside
+              className="mt-16 lg:mt-0"
+              style={{
+                fontFamily: '"Inter", system-ui, sans-serif',
+                paddingTop: 0,
+              }}
             >
-              &larr; Retour aux articles
-            </Link>
-          </div>
-        </div>
-
-        {/* Commentaires — colonne droite en desktop, sous l'article en mobile */}
-        {post.status !== "draft" && (
-          <div className="mt-10 lg:mt-0 lg:w-80 lg:shrink-0">
-            <div className="lg:sticky lg:top-8">
-              <h2 className="text-lg font-semibold text-gray-900 mb-4">Commentaires</h2>
-
-              <CommentForm
-                slug={post.slug}
-                onCommentAdded={() => setRefreshKey((k) => k + 1)}
-              />
-
-              <div className="mt-6">
-                <CommentSection
-                  comments={post.approved_comments}
+              <div className="lg:sticky lg:top-24 border-t border-editorial-rule lg:border-t-0 pt-12 lg:pt-0">
+                <CommentForm
                   slug={post.slug}
+                  onCommentAdded={() => setRefreshKey((k) => k + 1)}
+                  commentsCount={post.approved_comments?.length || 0}
                 />
+                <div className="mt-7">
+                  <CommentSection
+                    comments={post.approved_comments}
+                    slug={post.slug}
+                  />
+                </div>
               </div>
-            </div>
-          </div>
-        )}
+            </aside>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/blog/PostForm.jsx
+++ b/frontend/src/components/blog/PostForm.jsx
@@ -53,23 +53,47 @@ function SaveStatusIndicator({ saveStatus, lastSavedAt }) {
   if (saveStatus === "idle") return null;
 
   const statusConfig = {
-    saving: { text: "Sauvegarde en cours...", className: "text-gray-400" },
+    saving: {
+      text: "Sauvegarde en cours…",
+      dot: "#9a9a9a",
+      color: "#6b6b6b",
+    },
     saved: {
       text: lastSavedAt
-        ? `Brouillon sauvegardé à ${lastSavedAt}`
-        : "Brouillon sauvegardé",
-      className: "text-green-600",
+        ? `Brouillon enregistré · ${lastSavedAt}`
+        : "Brouillon enregistré",
+      dot: "#9ea69a",
+      color: "#6b6b6b",
     },
-    error: { text: "Erreur de sauvegarde", className: "text-red-500" },
+    error: {
+      text: "Erreur de sauvegarde",
+      dot: "#b54b1a",
+      color: "#b54b1a",
+    },
   };
 
   const config = statusConfig[saveStatus];
   if (!config) return null;
 
   return (
-    <p className={`text-xs ${config.className} mb-4`}>
+    <div
+      className="flex items-center gap-2 mb-4"
+      style={{
+        fontFamily: '"Inter", system-ui, sans-serif',
+        fontSize: 11,
+        color: config.color,
+      }}
+    >
+      <span
+        style={{
+          width: 6,
+          height: 6,
+          borderRadius: "50%",
+          background: config.dot,
+        }}
+      />
       {config.text}
-    </p>
+    </div>
   );
 }
 
@@ -456,16 +480,17 @@ export default function PostForm() {
 
   if (loading) {
     return (
-      <div className="max-w-2xl mx-auto px-4 py-12">
-        <p className="text-gray-500 text-center">Chargement...</p>
+      <div className="max-w-[760px] mx-auto px-5 sm:px-10 py-12">
+        <p className="text-editorial-dim text-center">Chargement…</p>
       </div>
     );
   }
 
   const pageTitle = isEdit ? "Modifier l'article" : "Ajouter un article";
+  const eyebrow = isEdit ? "Édition" : "Nouveau brouillon";
 
   return (
-    <div className="max-w-2xl mx-auto px-4 py-12">
+    <div className="max-w-[760px] mx-auto px-5 sm:px-10 py-12 lg:py-16">
       <Helmet>
         <title>{pageTitle}</title>
         <meta name="description" content={pageTitle} />
@@ -473,8 +498,27 @@ export default function PostForm() {
 
       <h1 className="sr-only">{pageTitle}</h1>
 
+      <div className="flex items-center justify-between mb-8">
+        <p
+          className="font-sans text-editorial-accent font-semibold"
+          style={{
+            fontSize: 11,
+            letterSpacing: 2,
+            textTransform: "uppercase",
+          }}
+        >
+          {eyebrow}
+        </p>
+        {isEdit && (
+          <SaveStatusIndicator
+            saveStatus={saveStatus}
+            lastSavedAt={lastSavedAt}
+          />
+        )}
+      </div>
+
       {errors.non_field_errors && (
-        <div className="mb-6 p-3 border border-red-200 rounded">
+        <div className="mb-6 p-3 border border-red-200 rounded-[3px] bg-red-50">
           {errors.non_field_errors.map((err, i) => (
             <p key={i} className="form-error">
               {err}
@@ -484,21 +528,19 @@ export default function PostForm() {
       )}
 
       <form onSubmit={handleSubmit} noValidate>
-        <div className="mb-5">
-          <label className="block text-sm font-medium text-gray-700 mb-2">
-            Image de couverture
-          </label>
+        <div className="mb-6">
+          <label className="form-label">Image de couverture</label>
           {coverImage ? (
             <div className="relative group">
               <img
                 src={coverImage}
                 alt="Image de couverture"
-                className="w-full h-48 object-cover rounded-lg"
+                className="w-full h-56 object-cover"
               />
               <button
                 type="button"
                 onClick={handleCoverImageDelete}
-                className="absolute top-2 right-2 bg-red-600 text-white rounded-full w-8 h-8 flex items-center justify-center opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity"
+                className="absolute top-2 right-2 bg-editorial-ink text-white rounded-full w-8 h-8 flex items-center justify-center opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity text-sm"
                 aria-label="Supprimer l'image de couverture"
                 title="Supprimer l'image de couverture"
               >
@@ -508,18 +550,22 @@ export default function PostForm() {
           ) : (
             <label
               htmlFor="cover-image-input"
-              className="flex items-center justify-center w-full h-32 border-2 border-dashed border-gray-300 rounded-lg cursor-pointer hover:border-gray-400 transition-colors"
+              className="flex items-center justify-center w-full h-36 border border-dashed border-editorial-rule bg-editorial-paper cursor-pointer hover:border-editorial-dim2 transition-colors"
             >
-              <div className="text-center">
+              <div className="text-center font-sans">
                 {coverImageUploading ? (
-                  <p className="text-sm text-gray-400">Upload en cours...</p>
+                  <p className="text-sm text-editorial-dim">Upload en cours…</p>
                 ) : (
                   <>
-                    <p className="text-sm text-gray-500">
-                      Cliquer pour ajouter une image de couverture
+                    <p className="text-sm text-editorial-text">
+                      Glisser une image ici
                     </p>
-                    <p className="text-xs text-gray-400 mt-1">
-                      JPEG, PNG, WebP ou GIF — 10 Mo max
+                    <p className="text-xs text-editorial-dim2 mt-1">
+                      ou{" "}
+                      <span className="text-editorial-ink2 underline">
+                        parcourir
+                      </span>
+                      {" "}· JPEG, PNG, WebP, GIF · 10 Mo max
                     </p>
                   </>
                 )}
@@ -536,7 +582,7 @@ export default function PostForm() {
           )}
         </div>
 
-        <div className="mb-5">
+        <div className="mb-6">
           <label htmlFor="title" className="sr-only">
             Titre
           </label>
@@ -550,9 +596,15 @@ export default function PostForm() {
             rows={1}
             maxLength={200}
             onInput={autoResize}
-            className={`w-full text-2xl sm:text-3xl font-bold text-gray-900 border-0 outline-none focus:ring-0 bg-transparent placeholder-gray-300 p-0 resize-none overflow-hidden break-words${
+            className={`w-full font-serif text-editorial-ink border-0 outline-none focus:ring-0 bg-transparent placeholder:text-editorial-dim2 p-0 resize-none overflow-hidden break-words leading-tight tracking-tight${
               errors.title ? " border-b-2 border-red-500" : ""
             }`}
+            style={{
+              fontSize: "clamp(28px, 4vw, 44px)",
+              fontWeight: 600,
+              letterSpacing: "-0.02em",
+              lineHeight: 1.08,
+            }}
           />
           {errors.title &&
             errors.title.map((err, i) => (
@@ -562,7 +614,7 @@ export default function PostForm() {
             ))}
         </div>
 
-        <div className="mb-5">
+        <div className="mb-6">
           <TagsInput
             label="Tags"
             placeholder="Ajouter des tags"
@@ -572,28 +624,34 @@ export default function PostForm() {
             onSearchChange={searchTags}
             maxDropdownHeight={200}
             clearable
+            classNames={{
+              label: "form-label",
+            }}
           />
         </div>
 
         {isEdit && postStatus === "published" && (
-          <div className="mb-5">
+          <div className="mb-6 py-4 border-y border-editorial-rule">
             <Switch
               checked={isPinned}
               onChange={handlePinToggle}
               disabled={pinToggling}
+              color="dark"
               label="Épingler à la une"
               description="L'article apparaîtra dans la section « À la une » de la page d'accueil (3 max)."
             />
           </div>
         )}
 
-        {isEdit && <SaveStatusIndicator saveStatus={saveStatus} lastSavedAt={lastSavedAt} />}
-
         <div className="mb-6">
           <label className="sr-only">Contenu</label>
           <div
-            style={{ minHeight: "300px" }}
-            className={errors.content ? "border border-red-500" : ""}
+            style={{ minHeight: "320px" }}
+            className={
+              errors.content
+                ? "border border-red-500"
+                : "border-t border-editorial-rule pt-6"
+            }
           >
             {contentReady && (
               <BlockNoteEditor
@@ -603,9 +661,14 @@ export default function PostForm() {
               />
             )}
           </div>
-          <p className="text-xs text-gray-400 mt-1">
-            Raccourcis : <kbd>Ctrl+B</kbd> gras, <kbd>Ctrl+I</kbd> italique,{" "}
-            <kbd>/</kbd> pour les blocs (titres, listes, etc.)
+          <p
+            className="font-sans text-editorial-dim2 mt-3"
+            style={{ fontSize: 11 }}
+          >
+            Raccourcis :{" "}
+            <kbd className="font-mono text-editorial-dim">Ctrl+B</kbd> gras,{" "}
+            <kbd className="font-mono text-editorial-dim">Ctrl+I</kbd> italique,{" "}
+            <kbd className="font-mono text-editorial-dim">/</kbd> pour les blocs
           </p>
           {errors.content &&
             errors.content.map((err, i) => (
@@ -616,7 +679,7 @@ export default function PostForm() {
         </div>
 
         {!isEdit && (
-          <div className="flex gap-3">
+          <div className="flex gap-3 mt-8">
             <button
               type="button"
               onClick={(e) => handleSubmit(e, { publish: false })}
@@ -635,12 +698,12 @@ export default function PostForm() {
         )}
       </form>
 
-      <div className="mt-6 text-center">
+      <div className="mt-10 pt-6 border-t border-editorial-rule">
         <Link
           to="/"
-          className="text-sm text-gray-500 hover:text-black transition-colors"
+          className="text-sm text-editorial-dim hover:text-editorial-ink transition-colors"
         >
-          Retour
+          ← Retour aux articles
         </Link>
       </div>
     </div>

--- a/frontend/src/components/blog/PostList.jsx
+++ b/frontend/src/components/blog/PostList.jsx
@@ -56,16 +56,17 @@ export default function PostList({ isHome = false }) {
 
   if (loading) {
     return (
-      <div className="max-w-3xl mx-auto px-4 py-12">
-        <p className="text-gray-500 text-center">Chargement...</p>
+      <div className="max-w-[1200px] mx-auto px-5 sm:px-10 py-12">
+        <p className="text-editorial-dim text-center">Chargement…</p>
       </div>
     );
   }
 
   const title = isHome ? "Derniers articles" : "Tous les articles";
+  const eyebrow = isHome ? "Journal" : "Archives";
 
   return (
-    <div className="max-w-3xl mx-auto px-4 py-12">
+    <div className="max-w-[1200px] mx-auto px-5 sm:px-10 py-12 lg:py-16">
       <Helmet>
         <title>{isHome ? "NICKORP" : title}</title>
         <meta
@@ -77,58 +78,84 @@ export default function PostList({ isHome = false }) {
           }
         />
       </Helmet>
+
+      <div className="max-w-[760px]">
+        <p
+          className="font-sans text-editorial-accent font-semibold mb-3"
+          style={{
+            fontSize: 11,
+            letterSpacing: 2,
+            textTransform: "uppercase",
+          }}
+        >
+          {eyebrow}
+        </p>
+        <div className="flex items-end justify-between gap-6 mb-12">
+          <h1
+            className="font-serif text-editorial-ink"
+            style={{
+              fontSize: "clamp(32px, 4.6vw, 54px)",
+              lineHeight: 1.05,
+              fontWeight: 600,
+              letterSpacing: "-0.02em",
+              margin: 0,
+            }}
+          >
+            {title}
+          </h1>
+          {!isHome && (
+            <Link
+              to="/"
+              className="text-sm text-editorial-dim hover:text-editorial-ink transition-colors shrink-0 pb-2"
+            >
+              ← Retour
+            </Link>
+          )}
+        </div>
+      </div>
+
       {isHome && pinnedPosts.length > 0 && (
         <FeaturedPosts posts={pinnedPosts} />
       )}
 
-      <div className="flex items-center justify-between mb-8">
-        <h1 className="text-3xl font-bold text-gray-900">{title}</h1>
-        {!isHome && (
-          <Link
-            to="/"
-            className="text-sm text-gray-500 hover:text-black transition-colors"
-          >
-            Retour
-          </Link>
+      <div className="max-w-[760px]">
+        {posts.length > 0 ? (
+          <>
+            <div className="border-t border-editorial-rule">
+              {posts.map((post) => (
+                <PostCard
+                  key={post.id}
+                  post={post}
+                  onChange={handlePostChange}
+                />
+              ))}
+            </div>
+
+            {isHome && showFullListLink && (
+              <div className="mt-10 text-center">
+                <Link
+                  to="/articles"
+                  className="text-sm text-editorial-dim hover:text-editorial-ink transition-colors"
+                >
+                  Voir tous les articles →
+                </Link>
+              </div>
+            )}
+
+            {!isHome && (
+              <Pagination
+                page={page}
+                totalPages={totalPages}
+                setSearchParams={setSearchParams}
+              />
+            )}
+          </>
+        ) : (
+          <p className="text-editorial-dim text-center mt-12 italic">
+            Aucun article pour le moment.
+          </p>
         )}
       </div>
-
-      {posts.length > 0 ? (
-        <>
-          <div>
-            {posts.map((post) => (
-              <PostCard
-                key={post.id}
-                post={post}
-                onChange={handlePostChange}
-              />
-            ))}
-          </div>
-
-          {isHome && showFullListLink && (
-            <div className="mt-8 text-center">
-              <Link
-                to="/articles"
-                className="text-sm text-gray-500 hover:text-black transition-colors"
-              >
-                Voir tous les articles
-              </Link>
-            </div>
-          )}
-
-          {!isHome && (
-            <Pagination
-              page={page}
-              totalPages={totalPages}
-              setSearchParams={setSearchParams}
-            />
-          )}
-        </>
-      ) : (
-        <p className="text-gray-500 text-center mt-12">
-          Aucun article pour le moment.
-        </p>
-      )}
     </div>
   );
 }

--- a/frontend/src/components/core/Contact.jsx
+++ b/frontend/src/components/core/Contact.jsx
@@ -2,40 +2,118 @@ import { Helmet } from "react-helmet-async";
 
 export default function Contact() {
   return (
-    <div className="max-w-3xl mx-auto px-4 py-12">
+    <div className="max-w-[760px] mx-auto px-5 sm:px-10 py-12 lg:py-16">
       <Helmet>
         <title>Contact &mdash; NICKORP</title>
-        <meta name="description" content="Contactez NICKORP \u2014 retrouvez-nous sur GitHub et LinkedIn." />
+        <meta
+          name="description"
+          content="Contactez NICKORP &mdash; retrouvez-nous sur GitHub et LinkedIn."
+        />
       </Helmet>
-      <h1 className="text-4xl font-bold text-gray-900 mb-8">Contact</h1>
 
-      <section className="mb-8">
-        <p className="text-gray-600 leading-relaxed mb-6">
-          Retrouvez-nous sur les plateformes suivantes :
-        </p>
-        <ul className="space-y-4">
-          <li>
-            <a
-              href="https://github.com/nicolasdeclerck/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-blue-600 hover:text-blue-800 font-medium"
+      <p
+        className="font-sans text-editorial-accent font-semibold mb-3"
+        style={{
+          fontSize: 11,
+          letterSpacing: 2,
+          textTransform: "uppercase",
+        }}
+      >
+        Échanger
+      </p>
+
+      <h1
+        className="font-serif text-editorial-ink"
+        style={{
+          fontSize: "clamp(32px, 4.6vw, 54px)",
+          lineHeight: 1.05,
+          fontWeight: 600,
+          letterSpacing: "-0.02em",
+          margin: "0 0 28px",
+        }}
+      >
+        Contact
+      </h1>
+
+      <p
+        className="font-serif text-editorial-dim italic"
+        style={{
+          fontSize: "clamp(17px, 2vw, 22px)",
+          lineHeight: 1.4,
+          margin: "0 0 40px",
+          maxWidth: 560,
+        }}
+      >
+        Une question, une suggestion, ou simplement envie de continuer la
+        conversation ailleurs.
+      </p>
+
+      <ul className="border-t border-editorial-rule">
+        <li className="border-b border-editorial-rule">
+          <a
+            href="https://github.com/nicolasdeclerck/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group flex items-baseline justify-between py-5 hover:bg-editorial-rule2 -mx-3 px-3 transition-colors"
+          >
+            <span>
+              <span
+                className="block text-editorial-dim font-sans"
+                style={{
+                  fontSize: 11,
+                  letterSpacing: 1.3,
+                  textTransform: "uppercase",
+                  fontWeight: 500,
+                  marginBottom: 4,
+                }}
+              >
+                Code
+              </span>
+              <span className="font-serif text-editorial-ink2 text-xl">
+                GitHub &mdash; nicolasdeclerck
+              </span>
+            </span>
+            <span
+              className="text-editorial-accent font-sans text-sm group-hover:translate-x-1 transition-transform"
+              aria-hidden
             >
-              GitHub &mdash; nicolasdeclerck
-            </a>
-          </li>
-          <li>
-            <a
-              href="https://www.linkedin.com/in/nicolas-declerck/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-blue-600 hover:text-blue-800 font-medium"
+              →
+            </span>
+          </a>
+        </li>
+        <li className="border-b border-editorial-rule">
+          <a
+            href="https://www.linkedin.com/in/nicolas-declerck/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group flex items-baseline justify-between py-5 hover:bg-editorial-rule2 -mx-3 px-3 transition-colors"
+          >
+            <span>
+              <span
+                className="block text-editorial-dim font-sans"
+                style={{
+                  fontSize: 11,
+                  letterSpacing: 1.3,
+                  textTransform: "uppercase",
+                  fontWeight: 500,
+                  marginBottom: 4,
+                }}
+              >
+                Pro
+              </span>
+              <span className="font-serif text-editorial-ink2 text-xl">
+                LinkedIn &mdash; Nicolas Declerck
+              </span>
+            </span>
+            <span
+              className="text-editorial-accent font-sans text-sm group-hover:translate-x-1 transition-transform"
+              aria-hidden
             >
-              LinkedIn &mdash; Nicolas Declerck
-            </a>
-          </li>
-        </ul>
-      </section>
+              →
+            </span>
+          </a>
+        </li>
+      </ul>
     </div>
   );
 }

--- a/frontend/src/components/layout/Footer.jsx
+++ b/frontend/src/components/layout/Footer.jsx
@@ -5,16 +5,19 @@ export default function Footer() {
   const { user } = useAuth();
 
   return (
-    <footer className="border-t border-gray-200">
-      <div className="max-w-3xl mx-auto px-4 py-6">
+    <footer className="border-t border-editorial-rule mt-12">
+      <div className="max-w-[1200px] mx-auto px-5 sm:px-10 py-8 text-center">
         {user && (
-          <p className="text-sm text-gray-400 text-center mb-2">
-            <Link to="/suivi-des-devs" className="hover:text-gray-600">
+          <p className="text-xs text-editorial-dim mb-2">
+            <Link
+              to="/suivi-des-devs"
+              className="hover:text-editorial-ink transition-colors"
+            >
               Suivi des devs
             </Link>
           </p>
         )}
-        <p className="text-sm text-gray-400 text-center">
+        <p className="text-xs text-editorial-dim tracking-wide">
           &copy; {new Date().getFullYear()} NICKORP
         </p>
       </div>

--- a/frontend/src/components/layout/Header.jsx
+++ b/frontend/src/components/layout/Header.jsx
@@ -26,17 +26,17 @@ export default function Header() {
   };
 
   return (
-    <header className="border-b border-gray-200">
-      <div className="max-w-3xl mx-auto px-4 py-4 flex items-center justify-between">
+    <header className="border-b border-editorial-rule bg-white sticky top-0 z-10">
+      <div className="max-w-[1200px] mx-auto px-5 sm:px-10 py-4 flex items-center justify-between">
         <Link
           to="/"
-          className="text-base font-semibold text-gray-900 hover:text-black"
+          className="text-sm font-semibold text-editorial-ink hover:text-editorial-ink2 tracking-[2px]"
         >
           NICKORP
         </Link>
 
         {/* Navigation desktop */}
-        <nav className="hidden md:flex items-center gap-6">
+        <nav className="hidden md:flex items-center gap-7">
           <Link to="/" className="nav-link">
             Accueil
           </Link>
@@ -68,10 +68,10 @@ export default function Header() {
                   <Avatar user={user} size="md" />
                 </button>
                 {dropdownOpen && (
-                  <div className="absolute right-0 mt-2 w-48 bg-white border border-gray-200 rounded shadow-lg py-1 z-50">
+                  <div className="absolute right-0 mt-2 w-48 bg-white border border-editorial-rule rounded-[3px] shadow-lg py-1 z-50">
                     <Link
                       to="/comptes/profil/modifier"
-                      className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+                      className="block px-4 py-2 text-sm text-editorial-text hover:bg-editorial-rule2"
                       onClick={() => setDropdownOpen(false)}
                     >
                       Mon profil
@@ -79,7 +79,7 @@ export default function Header() {
                     {user.is_superuser && (
                       <Link
                         to="/articles/mes-brouillons"
-                        className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+                        className="block px-4 py-2 text-sm text-editorial-text hover:bg-editorial-rule2"
                         onClick={() => setDropdownOpen(false)}
                       >
                         Mes brouillons
@@ -87,7 +87,7 @@ export default function Header() {
                     )}
                     <button
                       onClick={handleLogout}
-                      className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+                      className="block w-full text-left px-4 py-2 text-sm text-editorial-text hover:bg-editorial-rule2"
                     >
                       Se d&eacute;connecter
                     </button>
@@ -110,7 +110,7 @@ export default function Header() {
         {/* Hamburger mobile */}
         <button
           onClick={() => setMobileOpen(!mobileOpen)}
-          className="md:hidden inline-flex items-center justify-center p-2 rounded-md text-gray-600 hover:text-gray-900 hover:bg-gray-100"
+          className="md:hidden inline-flex items-center justify-center p-2 rounded-[3px] text-editorial-ink2 hover:text-editorial-ink hover:bg-editorial-rule2"
           aria-expanded={mobileOpen}
           aria-label="Menu de navigation"
         >
@@ -148,7 +148,7 @@ export default function Header() {
 
       {/* Menu mobile */}
       {mobileOpen && (
-        <div className="md:hidden border-t border-gray-200 px-4 py-4">
+        <div className="md:hidden border-t border-editorial-rule px-5 py-4">
           <nav className="flex flex-col gap-3">
             <Link
               to="/"
@@ -172,7 +172,7 @@ export default function Header() {
               Contact
             </Link>
           </nav>
-          <div className="mt-4 pt-4 border-t border-gray-200 flex flex-col gap-3">
+          <div className="mt-4 pt-4 border-t border-editorial-rule flex flex-col gap-3">
             {user ? (
               <>
                 <Link

--- a/frontend/src/components/ui/Pagination.jsx
+++ b/frontend/src/components/ui/Pagination.jsx
@@ -2,26 +2,33 @@ export default function Pagination({ page, totalPages, setSearchParams }) {
   if (totalPages <= 1) return null;
 
   return (
-    <div className="mt-8 flex items-center justify-center gap-4">
-      {page > 1 && (
-        <button
-          onClick={() => setSearchParams({ page: page - 1 })}
-          className="text-sm text-gray-500 hover:text-black transition-colors"
-        >
-          &larr; Pr&eacute;c&eacute;dent
-        </button>
-      )}
-      <span className="text-sm text-gray-400">
-        Page {page} sur {totalPages}
+    <div className="mt-12 pt-6 border-t border-editorial-rule flex items-center justify-between gap-4 font-sans">
+      <div className="flex-1">
+        {page > 1 && (
+          <button
+            onClick={() => setSearchParams({ page: page - 1 })}
+            className="text-sm text-editorial-dim hover:text-editorial-ink transition-colors"
+          >
+            ← Pr&eacute;c&eacute;dent
+          </button>
+        )}
+      </div>
+      <span
+        className="text-editorial-dim2 uppercase font-semibold"
+        style={{ fontSize: 11, letterSpacing: 1.6 }}
+      >
+        Page {page} / {totalPages}
       </span>
-      {page < totalPages && (
-        <button
-          onClick={() => setSearchParams({ page: page + 1 })}
-          className="text-sm text-gray-500 hover:text-black transition-colors"
-        >
-          Suivant &rarr;
-        </button>
-      )}
+      <div className="flex-1 text-right">
+        {page < totalPages && (
+          <button
+            onClick={() => setSearchParams({ page: page + 1 })}
+            className="text-sm text-editorial-dim hover:text-editorial-ink transition-colors"
+          >
+            Suivant →
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -46,27 +46,31 @@
   }
 
   .btn-primary {
-    @apply btn bg-black text-white hover:bg-gray-800 rounded;
+    @apply btn bg-editorial-ink text-white hover:bg-editorial-ink2;
+    border-radius: 3px;
   }
 
   .btn-secondary {
-    @apply btn border border-gray-300 text-gray-700 hover:bg-gray-50 rounded;
+    @apply btn border border-editorial-rule text-editorial-text bg-white hover:bg-editorial-rule2;
+    border-radius: 3px;
   }
 
   .btn-danger {
-    @apply btn border border-gray-300 text-gray-500 hover:text-gray-900 hover:bg-gray-50 rounded;
+    @apply btn border border-editorial-rule text-editorial-dim hover:text-editorial-ink hover:bg-editorial-rule2;
+    border-radius: 3px;
   }
 
   .card {
-    @apply py-6 border-b border-gray-200;
+    @apply py-7 border-b border-editorial-rule;
   }
 
   .form-label {
-    @apply block text-sm font-medium text-gray-700 mb-1;
+    @apply block text-xs uppercase tracking-[1.3px] font-semibold text-editorial-dim mb-2;
   }
 
   .form-input {
-    @apply w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-black focus:border-black transition text-sm;
+    @apply w-full px-3 py-2 border border-editorial-rule bg-white text-editorial-text focus:outline-none focus:ring-1 focus:ring-editorial-ink focus:border-editorial-ink transition text-sm;
+    border-radius: 3px;
   }
 
   .form-error {
@@ -74,7 +78,7 @@
   }
 
   .nav-link {
-    @apply text-sm text-gray-500 hover:text-black transition-colors;
+    @apply text-sm text-editorial-dim hover:text-editorial-ink transition-colors;
   }
 }
 

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -87,3 +87,149 @@
 .bn-editor .ProseMirror:focus-visible {
   outline: none !important;
 }
+
+/* Article prose — editorial typography for rendered BlockNote content */
+.article-prose {
+  font-family:
+    "Source Serif 4", "Source Serif Pro", Georgia, serif;
+  color: #2a2a2a;
+  font-size: 20px;
+  line-height: 1.65;
+}
+
+@media (max-width: 767px) {
+  .article-prose {
+    font-size: 18px;
+  }
+}
+
+.article-prose > :first-child {
+  margin-top: 0;
+}
+
+.article-prose > :last-child {
+  margin-bottom: 0;
+}
+
+.article-prose p {
+  margin: 0 0 24px;
+}
+
+.article-prose h1,
+.article-prose h2,
+.article-prose h3,
+.article-prose h4 {
+  font-family:
+    "Source Serif 4", "Source Serif Pro", Georgia, serif;
+  color: #111;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.article-prose h1 {
+  font-size: clamp(28px, 3.2vw, 36px);
+  line-height: 1.15;
+  margin: 48px 0 18px;
+}
+
+.article-prose h2 {
+  font-size: clamp(24px, 2.6vw, 30px);
+  line-height: 1.2;
+  margin: 40px 0 16px;
+  letter-spacing: -0.3px;
+}
+
+.article-prose h3 {
+  font-size: clamp(20px, 2.1vw, 24px);
+  line-height: 1.3;
+  margin: 32px 0 12px;
+}
+
+.article-prose h4 {
+  font-size: 18px;
+  line-height: 1.35;
+  margin: 28px 0 10px;
+}
+
+.article-prose blockquote {
+  margin: 32px 0;
+  padding: 4px 0 4px 24px;
+  border-left: 2px solid #111;
+  font-family:
+    "Source Serif 4", "Source Serif Pro", Georgia, serif;
+  font-style: italic;
+  font-size: clamp(20px, 2.2vw, 26px);
+  line-height: 1.4;
+  color: #1f1f1f;
+}
+
+.article-prose a {
+  color: #111;
+  text-decoration: underline;
+  text-decoration-color: #b54b1a;
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1.5px;
+}
+
+.article-prose a:hover {
+  text-decoration-color: #111;
+}
+
+.article-prose strong,
+.article-prose b {
+  font-weight: 600;
+  color: #111;
+}
+
+.article-prose em,
+.article-prose i {
+  font-style: italic;
+}
+
+.article-prose code {
+  font-family:
+    ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.9em;
+  background: #f0efeb;
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+
+.article-prose pre {
+  font-family:
+    ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  background: #f0efeb;
+  padding: 16px 20px;
+  border-radius: 4px;
+  overflow-x: auto;
+  font-size: 14px;
+  line-height: 1.55;
+  margin: 24px 0;
+}
+
+.article-prose pre code {
+  background: transparent;
+  padding: 0;
+}
+
+.article-prose ul,
+.article-prose ol {
+  margin: 0 0 24px;
+  padding-left: 1.5em;
+}
+
+.article-prose li {
+  margin-bottom: 8px;
+}
+
+.article-prose img {
+  max-width: 100%;
+  height: auto;
+  margin: 32px 0;
+}
+
+.article-prose hr {
+  border: none;
+  border-top: 1px solid #e7e5e0;
+  margin: 40px 0;
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -5,6 +5,25 @@ export default {
     extend: {
       fontFamily: {
         sans: ["Inter", "system-ui", "sans-serif"],
+        serif: [
+          "'Source Serif 4'",
+          "'Source Serif Pro'",
+          "Georgia",
+          "serif",
+        ],
+      },
+      colors: {
+        editorial: {
+          ink: "#111111",
+          ink2: "#1f1f1f",
+          text: "#2a2a2a",
+          dim: "#6b6b6b",
+          dim2: "#9a9a9a",
+          rule: "#e7e5e0",
+          rule2: "#f0efeb",
+          paper: "#fbfaf7",
+          accent: "#b54b1a",
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary

Refonte de la page de détail d'article en direction éditoriale (NYT / Substack), puis harmonisation du reste du site (accueil, liste d'articles, éditeur, contact, header/footer) sur la même direction. Source d'inspiration : design Claude Design exporté en HTML/JSX (Source Serif 4 pour le corps de lecture, Inter pour le chrome UI, accent terracotta).

## Ce qui change

**Direction visuelle**
- Source Serif 4 chargée depuis Google Fonts pour titres et corps d'articles
- Palette \`editorial\` (\`ink #111\`, \`text #2a2a2a\`, \`dim #6b6b6b\`, \`rule #e7e5e0\`, \`paper #fbfaf7\`, \`accent #b54b1a\`) ajoutée à \`tailwind.config.js\`
- \`.btn-*\`, \`.nav-link\`, \`.card\`, \`.form-*\`, \`.form-label\` repalettés en globals

**Page de détail (\`PostDetail\`)** — commit \`3ce268c\`
- Eyebrow topic terracotta + h1 serif 54px (clamp), byline avec temps de lecture
- Barre utilitaire « AUTEUR » consolidée (Modifier / Publier / Épingler / Versions / Supprimer)
- Sidebar commentaires 320px à droite (inline en mobile), formulaire compact, dates relatives
- CSS \`.article-prose\` pour le rendu BlockNote (h2/blockquote/code/pre/links)

**Harmonisation** — commit \`a301a33\`
- **Home / Articles** : eyebrow JOURNAL / ARCHIVES, h1 serif clamp, cards stackées avec rule, vignette de couverture 160×112 à droite
- **FeaturedPosts** : section header avec rule, cartes éditoriales, fallback de couverture en \`paper\`
- **Contact** : eyebrow ÉCHANGER, h1 serif, sous-titre italique, liens Code/Pro avec flèche terracotta au hover
- **PostForm (éditeur)** : eyebrow ÉDITION / NOUVEAU BROUILLON, dropzone \`paper\` dashed, titre serif 44px (input), indicateur de sauvegarde compact (dot + label)
- **Header** : sticky max-w-1200, NICKORP letter-spacing 2, dropdown profil repalette
- **Footer** : éditorial, breathing room
- **Pagination** : footer rule, indicateur de page en uppercase

## Notes pour la review

- L'éditeur BlockNote rend en sans-serif (Inter) — c'est volontaire, le rendu serif est sur la page publiée via \`.article-prose\`. Faisable plus tard si on veut du WYSIWYG, mais fragile aux upgrades de la lib.
- Pas de subtitle/deck dans le modèle Post — non rendu pour l'instant.
- Source Serif 4 chargée depuis Google Fonts (le reste du site sert Inter en local). Peut être servie localement aussi si on veut éviter la dépendance externe.

## Test plan

- [ ] \`/\` (home) — eyebrow + h1 serif, cards, dropdown auth visible si connecté
- [ ] \`/articles\` — variante ARCHIVES, pagination en bas
- [ ] \`/articles/<slug>\` — desktop : sidebar commentaires à droite ; mobile : inline sous l'article ; barre AUTEUR si propriétaire
- [ ] \`/articles/<slug>/modifier\` — autosave + status indicator, dropzone, title input serif
- [ ] \`/articles/creer\` — état vide, titre placeholder serif
- [ ] \`/contact\` — eyebrow + h1 + liens Code/Pro
- [ ] Mobile (375px) : header avec hamburger, h1 réduit (clamp), barre AUTEUR wrappe sur 2 lignes
- [ ] Régressions : login/inscription, profil, suppression d'article, versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)