### PR TITLE
Remove bottom margin from article prose paragraphs

### DIFF
--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -120,7 +120,7 @@
 }
 
 .article-prose p {
-  margin: 0 0 24px;
+  margin: 0;
 }
 
 .article-prose h1,


### PR DESCRIPTION
## Summary
Removed the bottom margin from paragraphs within article prose content to reduce spacing between paragraph elements.

## Changes
- Updated `.article-prose p` margin from `0 0 24px` to `0`, eliminating the 24px bottom margin while maintaining zero top and left/right margins

## Details
This change affects the vertical spacing of paragraphs in article content. The previous styling added 24px of space below each paragraph, which is now removed. This may be part of a broader layout adjustment or spacing refinement for article typography.

https://claude.ai/code/session_015jchYoAVRF6hhGzUPYzZvn