### PR TITLE
chore: ajouter les skills create-github-issue et implement-github-issue

### DIFF
--- a/.claude/skills/create-github-issue/SKILL.md
+++ b/.claude/skills/create-github-issue/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: create-github-issue
+description: Create a new GitHub issue — gather context, draft a well-structured ticket (title, body, labels, assignees), confirm with the user, then open it via the GitHub MCP. Use ONLY when the user explicitly asks to create / open / file a new issue or ticket (e.g. "create an issue for X", "open a ticket about Y", "file a bug", "crée un ticket", "ouvre une issue"). Do NOT trigger when the user wants to implement, work on, fix, or resolve an EXISTING issue — that is handled by `implement-github-issue`.
+---
+
+# Create a GitHub issue
+
+This skill helps the user file a high-quality GitHub issue from a free-form request. It uses the GitHub MCP tools (`mcp__github__*`). It never writes code, never creates a branch, and never opens a pull request — its single output is a new issue on GitHub.
+
+## When to use it
+
+Trigger this skill **only** when the user explicitly asks to **create a new issue/ticket**. Typical signals:
+
+- "Create an issue for …"
+- "Open a ticket about …"
+- "File a bug / feature request …"
+- "Ouvre / crée une issue / un ticket …"
+- "Add this to the backlog as an issue"
+
+### Do NOT trigger this skill when
+
+- The user asks to **implement / work on / pick up / fix / resolve** an existing issue → use `implement-github-issue` instead.
+- The user references an existing issue by number or URL without asking to create a new one → likely `implement-github-issue` or a read-only answer.
+- The user wants to **comment** on an issue → use `mcp__github__add_issue_comment` directly, no skill needed.
+- The user wants to **close / reopen / relabel** an existing issue → use `mcp__github__issue_write` directly, no skill needed.
+
+If the request is ambiguous ("let's track this somewhere"), **ask the user** whether they want a new issue created before invoking this skill.
+
+## Boundary with `implement-github-issue`
+
+| Intent signal                                 | Skill                      |
+| --------------------------------------------- | -------------------------- |
+| "create / open / file / crée / ouvre" + issue | **create-github-issue**    |
+| "implement / work on / fix / resolve" + #ref  | `implement-github-issue`   |
+| Both signals in the same request              | Ask the user which one first — normally **create first, implement after**. |
+
+Never chain into `implement-github-issue` automatically after creating the ticket. Ask the user if they want to proceed with implementation as a separate step.
+
+## Required tool
+
+- `mcp__github__issue_write` with method `create` — the only write this skill performs.
+
+Helpful read-only tools to prepare the issue:
+
+- `mcp__github__list_issues` / `mcp__github__search_issues` — check for duplicates.
+- `mcp__github__get_label` — verify labels exist on the repo before applying them.
+- `mcp__github__get_teams` / `mcp__github__get_me` — resolve assignees if the user names them.
+- `Grep` / `Glob` / `Read` — pull concrete file references or line numbers from the local repo to cite in the issue body.
+
+## Workflow
+
+Follow these phases in order. Keep each one short — the goal is a good ticket, not a novel.
+
+### 1. Capture the user's intent
+
+Summarize back to the user in one sentence:
+
+- **Type**: bug, feature, chore, docs, question, etc.
+- **Target repository**: default to the current repository (`nicolasdeclerck/skills-assessment`) unless the user names another. **Never** create an issue on a repo outside the authorized scope.
+- **Rough subject**: what the issue is about.
+
+If any of the three is unclear, ask **one** clarifying question before continuing.
+
+### 2. Gather context (lightweight)
+
+Do the minimum needed to write a useful issue:
+
+- For a **bug**: reproduction steps, expected vs. actual behaviour, environment, a file:line reference if the user has hinted at where it lives.
+- For a **feature**: user-facing goal, motivation, a rough acceptance criteria list.
+- For a **chore / refactor / docs**: scope and motivation.
+
+Optionally run one or two `Grep`/`Read` calls to anchor the issue in real file paths — but do not dive deep. If you find yourself reading more than 2–3 files, stop: that's implementation territory, not ticket drafting.
+
+### 3. Check for duplicates
+
+Call `mcp__github__search_issues` with a short query derived from the subject (state `open`). If a plausible duplicate exists:
+
+- Show the user the top 1–3 matches (number, title, state).
+- Ask whether to proceed anyway, comment on the existing issue instead, or abort.
+
+### 4. Draft the issue
+
+Produce a draft using `templates/issue-body.md`. Required fields:
+
+- **Title** — imperative, ≤ 70 chars, no issue-number prefix, no trailing period. Examples:
+  - `login accepts empty password`
+  - `add dark mode toggle to settings`
+  - `document postgres migration path`
+- **Body** — filled-in template (see below).
+- **Labels** — only labels that already exist on the repo. If unsure, leave empty and note it.
+- **Assignees** — only if the user named someone explicitly.
+
+Show the full draft to the user (title, body, labels, assignees) and **wait for explicit approval** before creating. Accept small edits in-place; re-show the draft after edits.
+
+### 5. Create the issue
+
+Once approved, call `mcp__github__issue_write` with method `create`:
+
+- `owner` / `repo` — target repository.
+- `title` — from the draft.
+- `body` — the rendered template.
+- `labels` — array of existing label names, or omit.
+- `assignees` — array of GitHub logins, or omit.
+
+Return the new issue's URL and number to the user.
+
+### 6. Offer next steps (do not auto-chain)
+
+After creation, ask the user if they want to:
+
+- Implement the issue now → hand off to `implement-github-issue` **only on explicit confirmation**.
+- Add extra comments, link related issues, or adjust labels.
+- Nothing further — stop.
+
+## Supporting files
+
+- `templates/issue-body.md` — the issue body template, with bug / feature / chore variants.
+
+## Guardrails
+
+- **Scope lock**: only create issues on repositories in the authorized scope. Refuse others and tell the user why.
+- **No implementation work**: never create a branch, never edit source files, never open a PR from this skill.
+- **No auto-labelling**: only apply labels that already exist on the repo — check with `mcp__github__get_label` or `mcp__github__list_issues` if unsure.
+- **No duplicates without acknowledgement**: always run the duplicate check in step 3.
+- **Respect the user's wording**: keep the user's technical terms in the title and body; do not rename their feature.
+- **One issue per call**: if the user describes multiple distinct problems, propose splitting into separate tickets rather than bundling.
+- **Never close or modify unrelated issues** as part of this workflow.

--- a/.claude/skills/create-github-issue/templates/issue-body.md
+++ b/.claude/skills/create-github-issue/templates/issue-body.md
@@ -1,0 +1,81 @@
+<!--
+Issue body template. Pick the variant that matches the issue type and
+delete the others. Remove any section that does not apply. Keep the final
+rendered body concise — a good ticket fits on one screen.
+-->
+
+## Bug report
+
+### Summary
+<!-- One sentence: what is broken. -->
+
+### Steps to reproduce
+1.
+2.
+3.
+
+### Expected behaviour
+<!-- What should happen. -->
+
+### Actual behaviour
+<!-- What actually happens. Paste error messages / stack traces in a code block. -->
+
+```
+<logs or stack trace>
+```
+
+### Environment
+<!-- Remove lines that don't apply. -->
+- App version / commit:
+- Browser / OS:
+- Backend (Django) version:
+- Frontend (Vite/React) version:
+- Database: SQLite / Postgres
+
+### Relevant code
+<!-- file:line references, not full pastes. -->
+-
+
+---
+
+## Feature request
+
+### Problem
+<!-- What user-facing need is not met today. -->
+
+### Proposed solution
+<!-- High-level shape of the change. Keep it short — implementation details belong in the PR. -->
+
+### Acceptance criteria
+- [ ]
+- [ ]
+- [ ]
+
+### Out of scope
+<!-- Things explicitly NOT included, so reviewers don't expand the ticket. -->
+-
+
+### Alternatives considered
+<!-- Optional. Remove if none. -->
+-
+
+---
+
+## Chore / refactor / docs
+
+### Motivation
+<!-- Why this needs to happen now. -->
+
+### Scope
+<!-- What will change, concisely. -->
+-
+
+### Non-goals
+<!-- What this ticket is deliberately NOT about. -->
+-
+
+---
+
+## Additional context
+<!-- Screenshots, links to related issues or PRs, discussion threads. Remove if empty. -->
+-

--- a/.claude/skills/implement-github-issue/SKILL.md
+++ b/.claude/skills/implement-github-issue/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: implement-github-issue
+description: Guide end-to-end for implementing an existing GitHub issue — load the issue, understand the code, plan, implement on a dedicated branch, open a PR that links back to the issue, and update the issue. Use whenever the user asks to "work on", "implement", "pick up", "fix" or "resolve" a GitHub issue, or references an issue by number/URL (e.g. "implement #42", "owner/repo#123", "https://github.com/owner/repo/issues/42").
+---
+
+# Implement a GitHub issue
+
+This skill turns a GitHub issue into a merged pull request following a disciplined, reviewable workflow. It is designed for the GitHub MCP tools (`mcp__github__*`).
+
+## When to use it
+
+Trigger this skill when the user:
+
+- Asks to implement / work on / pick up / fix / resolve a GitHub issue.
+- References an issue by number (`#42`), short ref (`owner/repo#42`), or URL.
+- Says things like "start this ticket", "let's tackle this issue", "take this one".
+
+Do **not** trigger this skill for:
+
+- Creating a new issue (different workflow).
+- Pure questions about an issue that don't involve code changes.
+- Quick read-only triage.
+
+## Required tools
+
+Use the GitHub MCP tools. Do not attempt to use `gh` CLI. Key tools:
+
+- `mcp__github__issue_read` — load the issue, comments, labels.
+- `mcp__github__search_code` / `Grep` / `Glob` — locate relevant code.
+- `mcp__github__create_pull_request`, `mcp__github__update_pull_request` — open/update PR.
+- `mcp__github__add_issue_comment` — post progress comments.
+- `mcp__github__issue_write` — transition labels/state if the user wants it closed.
+
+## Workflow
+
+Follow these phases **in order**. Do not skip phases without the user's agreement.
+
+### 1. Load the issue
+
+Always start here. Never implement from memory of the issue.
+
+1. Call `mcp__github__issue_read` with method `get` for the target issue.
+2. Also read comments (method `get_comments`) — decisions and clarifications often live there.
+3. Extract and summarize for the user:
+   - **Goal** (one sentence)
+   - **Acceptance criteria** (bullet list — infer them if not explicit)
+   - **Scope boundaries** (what's explicitly out of scope)
+   - **Labels** (`bug`, `feature`, `good-first-issue`, etc.) — they inform branch prefix and PR type
+   - **Linked PRs or issues** — check for prior art or duplicates
+   - **Assignees / reviewers** requested
+
+If the issue is ambiguous or contradictory, **stop and ask** before writing code.
+
+### 2. Understand the code
+
+Before planning, explore the codebase:
+
+1. Use `Grep`/`Glob` to find the files, functions, or modules mentioned in the issue.
+2. Read those files fully (not just snippets) — understand surrounding code.
+3. Identify tests that cover the affected area.
+4. Note any project conventions (CLAUDE.md, CONTRIBUTING.md, lint config, commit style).
+
+### 3. Plan and confirm
+
+Produce a **short, concrete plan** and share it with the user before coding:
+
+- Files to create/modify (with paths).
+- High-level approach per file.
+- Tests to add or update.
+- Risks / open questions.
+- Commands to verify locally (build, test, lint).
+
+**Wait for explicit user approval** unless the issue is trivial (typo, one-line fix) and the user asked to proceed autonomously. See `references/workflow.md` for edge cases.
+
+### 4. Prepare the branch
+
+1. Create a branch from the default branch using the naming convention in `references/conventions.md`.
+   - Format: `<type>/<issue-number>-<kebab-slug>` (e.g. `fix/42-null-pointer-login`, `feat/108-dark-mode`).
+2. If a branch already exists for the user's session (check current branch), stay on it — don't switch.
+3. Never commit directly to `main`/`master`.
+
+### 5. Implement
+
+- Make the minimum change that satisfies the acceptance criteria. No drive-by refactors.
+- Commit in logical units with messages following `references/conventions.md`.
+- Run tests, linters, and type-checkers after each meaningful change.
+- If you discover the plan is wrong, **pause and revise the plan with the user** — don't silently pivot.
+
+### 6. Verify
+
+Before opening a PR:
+
+- All acceptance criteria met (re-read the issue).
+- Tests pass locally.
+- Linter / formatter / type-checker clean.
+- No stray debug prints, commented-out code, or TODOs you introduced.
+- Diff reviewed by you as if you were the reviewer.
+
+### 7. Open the pull request
+
+1. Push the branch: `git push -u origin <branch>`.
+2. Create the PR with `mcp__github__create_pull_request`:
+   - **Title**: short, imperative, under 70 chars. Include issue number if convention allows.
+   - **Body**: use `templates/pr-description.md`. Must contain `Fixes #<number>` (or `Closes #<number>`) so GitHub auto-closes the issue on merge.
+   - Target the default branch.
+   - Request reviewers from the issue's assignees or the suggested reviewers in CODEOWNERS if present.
+3. Do **not** merge the PR yourself unless the user explicitly asks.
+
+### 8. Update the issue
+
+Post a progress comment on the issue using `templates/issue-progress-comment.md`:
+
+- Link to the PR.
+- Summarize what was done.
+- Flag any remaining sub-tasks or follow-ups.
+
+Do not close the issue manually — let the PR close it on merge via `Fixes #<n>`.
+
+### 9. Offer PR-activity subscription
+
+After the PR is open, proactively ask the user if they want the session to subscribe to PR activity (CI, review comments) via `subscribe_pr_activity`, so you can react to review feedback and CI failures.
+
+## Supporting files
+
+- `references/workflow.md` — edge cases, multi-issue PRs, draft PRs, stacked PRs, hotfixes.
+- `references/conventions.md` — branch naming, commit messages, PR titles, labels.
+- `templates/pr-description.md` — PR body template.
+- `templates/issue-progress-comment.md` — progress-comment template.
+
+## Guardrails
+
+- **Never force-push** to `main`/`master` or to a branch you don't own.
+- **Never close an issue directly** — always via the PR.
+- **Never push without committing first**, and never commit secrets.
+- **Never skip hooks** (`--no-verify`) to make a commit succeed — fix the root cause.
+- If the issue has `wontfix`, `duplicate`, or `needs-triage` labels, **stop and confirm** with the user.
+- If the PR would touch more than ~500 lines, flag it and propose splitting.

--- a/.claude/skills/implement-github-issue/references/conventions.md
+++ b/.claude/skills/implement-github-issue/references/conventions.md
@@ -1,0 +1,89 @@
+# Conventions
+
+These are the default conventions. If the repository has a `CONTRIBUTING.md`, `CLAUDE.md`, or observable patterns in recent commits/PRs that contradict these defaults, **follow the repository's conventions instead**.
+
+## Branch naming
+
+Format: `<type>/<issue-number>-<kebab-slug>`
+
+| Type    | When to use                             | Example                                |
+| ------- | --------------------------------------- | -------------------------------------- |
+| `feat`  | New user-facing feature                 | `feat/108-dark-mode-toggle`            |
+| `fix`   | Bug fix                                 | `fix/42-null-pointer-login`            |
+| `chore` | Tooling, CI, deps, no behaviour change  | `chore/77-bump-eslint-9`               |
+| `docs`  | Documentation only                      | `docs/53-clarify-install-steps`        |
+| `refactor` | Internal refactor, no behaviour change | `refactor/91-extract-auth-service`   |
+| `test`  | Adding or fixing tests only             | `test/66-cover-password-reset`         |
+| `perf`  | Performance improvement                 | `perf/120-memoize-product-list`        |
+
+Rules:
+
+- Slug: lowercase, dashes only, ~3–6 words, no stop words.
+- Never include ticket titles verbatim — summarize.
+- If the repo uses a different prefix scheme (e.g. `username/...`), follow it.
+
+## Commit messages
+
+Use Conventional Commits unless the repo clearly uses another style:
+
+```
+<type>(<optional-scope>): <imperative summary>
+
+<optional body explaining the *why*, wrapped at 72 chars>
+
+Refs #<issue-number>
+```
+
+- `<type>` matches the branch type (`feat`, `fix`, …).
+- Summary: imperative mood, lowercase, no trailing period, ≤ 72 chars.
+- Body: explain *why*, not *what* (the diff shows the what).
+- Footer: `Refs #<n>` on every commit; `Fixes #<n>` only on the commit that resolves the issue (or in the PR body).
+
+Examples:
+
+```
+fix(auth): reject empty password on login
+
+The login handler accepted an empty string because the presence check
+ran before trim(). Users could bypass the length rule by sending
+whitespace-only passwords.
+
+Refs #42
+```
+
+```
+feat(ui): add dark mode toggle to settings
+
+Refs #108
+```
+
+## Pull request titles
+
+Same rules as commit summaries:
+
+- Imperative, lowercase, ≤ 70 chars.
+- Prefix with type if the repo uses Conventional PR titles.
+- Do **not** embed the issue number in the title unless the repo convention requires it — the PR body handles linking.
+
+Good: `fix(auth): reject empty password on login`
+Bad: `Fixed bug where login accepted empty password (fixes #42)`
+
+## Labels
+
+Apply labels that match the issue:
+
+- Carry over `bug` / `enhancement` / `documentation` from the issue.
+- Add `ready-for-review` when leaving draft state, if the repo uses it.
+- Add `needs-tests` if you deliberately deferred test coverage (and flag in PR body).
+
+## Reviewers
+
+- Request reviewers from the issue's assignees first.
+- Fall back to `CODEOWNERS` entries for the touched paths.
+- If neither exists, leave unassigned and mention it in the PR body.
+
+## Line-count targets
+
+- Aim for < 400 changed lines per PR.
+- At 400–800 lines, flag it and justify.
+- Over 800 lines, propose splitting before opening.

--- a/.claude/skills/implement-github-issue/references/workflow.md
+++ b/.claude/skills/implement-github-issue/references/workflow.md
@@ -1,0 +1,81 @@
+# Workflow — edge cases
+
+This document covers situations the main `SKILL.md` workflow does not handle directly.
+
+## Trivial issues (typos, one-line fixes)
+
+If the issue is a typo, a comment fix, or a clearly-scoped one-line change:
+
+- Skip the explicit plan-approval step.
+- Still load the issue, open a branch, open a PR linking the issue.
+- Keep the commit message and PR body short but correct.
+
+## Ambiguous or stale issues
+
+If the issue:
+
+- Was opened more than 12 months ago with no recent activity, **or**
+- Has contradictory comments (e.g. discussion changed the scope), **or**
+- References files/APIs that no longer exist,
+
+then **pause** and ask the user for clarification before planning. Propose what you think the current intent is and wait for confirmation.
+
+## Multi-issue PR
+
+If a single change naturally closes several issues:
+
+- Reference all of them in the PR body: `Fixes #12`, `Fixes #13`, `Closes #14` (one per line — GitHub only parses separate keywords).
+- Comment on each issue with a link to the PR.
+- Mention in the PR description why they are bundled.
+
+Prefer **one PR per issue** when issues are logically independent.
+
+## Stacked / dependent PRs
+
+If the work depends on another PR that isn't merged yet:
+
+- Branch off the dependency's branch, not `main`.
+- In the PR body, add `Depends on #<PR number>` and mark the PR as **draft** until the base is merged.
+- After the base merges, rebase onto `main` and mark ready for review.
+
+## Draft PRs
+
+Open as draft when:
+
+- You want CI feedback before finishing.
+- The work will take multiple sessions and you want early reviewer input.
+- Acceptance criteria are still being negotiated with the issue author.
+
+Use `mcp__github__create_pull_request` with `draft: true`.
+
+## Hotfixes
+
+For issues labelled `hotfix` / `critical` / `P0`:
+
+- Branch off the current release branch if one exists (not `main`).
+- Keep the diff minimal — no refactors.
+- Add `hotfix` to the PR labels.
+- Ping the on-call reviewer in the PR body.
+
+## Follow-up work
+
+If during implementation you discover additional problems that are **out of scope**:
+
+- Do **not** fix them in the same PR.
+- Note them in the PR body under a `## Follow-ups` section.
+- Offer to open separate issues after the PR is merged.
+
+## Reverting a merged PR
+
+If the user asks to revert a merged PR that closed an issue:
+
+- Open the revert PR with `Reopens #<n>` in the body (GitHub does not auto-reopen, so also manually reopen via `issue_write` after merge).
+- Add a comment on the original issue explaining why the fix was reverted.
+
+## Handling review feedback
+
+When subscribed to PR activity:
+
+- For each review comment, decide: (a) apply the suggestion, (b) push back with reasoning, or (c) ask the user.
+- For CI failures, read the logs, diagnose the root cause, fix, and push a new commit.
+- Never force-push on a PR under review unless explicitly allowed — prefer fixup commits.

--- a/.claude/skills/implement-github-issue/templates/issue-progress-comment.md
+++ b/.claude/skills/implement-github-issue/templates/issue-progress-comment.md
@@ -1,0 +1,21 @@
+<!-- Post this comment on the issue once the PR is open. -->
+
+Work in progress in #<PR_NUMBER>.
+
+**Summary of the approach**
+
+<!-- 1-3 sentences. What was done, any deviation from the original proposal. -->
+
+**Acceptance criteria status**
+
+- [x] <criterion 1>
+- [x] <criterion 2>
+- [ ] <criterion still pending, if any>
+
+**Out of scope / follow-ups**
+
+<!-- Remove if none. Mention any follow-up issues you plan to open. -->
+
+-
+
+The issue will close automatically when #<PR_NUMBER> merges.

--- a/.claude/skills/implement-github-issue/templates/pr-description.md
+++ b/.claude/skills/implement-github-issue/templates/pr-description.md
@@ -1,0 +1,44 @@
+## Summary
+
+<!-- 1-3 bullets describing what changed and why. Focus on the "why". -->
+
+-
+-
+
+Fixes #<ISSUE_NUMBER>
+
+## Changes
+
+<!-- Brief list of the concrete changes. One bullet per meaningful change. -->
+
+-
+-
+
+## How it was tested
+
+<!-- List the commands run and/or manual verification steps. -->
+
+- [ ] `<test command>`
+- [ ] `<lint / typecheck command>`
+- [ ] Manual verification: <steps>
+
+## Screenshots / recordings
+
+<!-- Remove this section if not a UI change. -->
+
+## Risks and rollout
+
+<!-- Anything reviewers should scrutinise: migrations, feature flags, backward-compat, performance. -->
+
+-
+
+## Follow-ups
+
+<!-- Things deliberately out of scope. Remove the section if none. -->
+
+-
+
+---
+
+<!-- Do not edit below this line. -->
+Closes #<ISSUE_NUMBER>


### PR DESCRIPTION
## Summary
- Réplique les deux skills du repo `skills-assessment` dans ce repo
- `create-github-issue` : skill pour créer des tickets GitHub
- `implement-github-issue` : skill pour traiter/implémenter des tickets GitHub

## Test plan
- [ ] Vérifier que les skills apparaissent dans le Skill loader
- [ ] Tester `create-github-issue` sur un ticket fictif
- [ ] Tester `implement-github-issue` sur un ticket existant

🤖 Generated with [Claude Code](https://claude.com/claude-code)