### PR TITLE
feat(profile): move delete avatar button next to avatar

### DIFF
--- a/frontend/src/components/accounts/ProfileEdit.jsx
+++ b/frontend/src/components/accounts/ProfileEdit.jsx
@@ -61,8 +61,35 @@ export default function ProfileEdit() {
   return (
     <div className="max-w-sm mx-auto px-4 py-16">
       {user.avatar && (
-        <div className="mb-6 flex justify-center">
+        <div className="mb-6 flex flex-col items-center gap-3">
           <Avatar user={user} size="lg" />
+          {!showDeleteConfirm ? (
+            <button
+              type="button"
+              onClick={() => setShowDeleteConfirm(true)}
+              className="text-sm text-red-600 hover:text-red-800 underline"
+            >
+              Supprimer l&apos;avatar
+            </button>
+          ) : (
+            <div className="flex items-center justify-center gap-3">
+              <button
+                type="button"
+                onClick={handleDeleteAvatar}
+                disabled={isDeleting}
+                className="text-sm text-white bg-red-600 hover:bg-red-700 px-3 py-1 rounded disabled:opacity-50"
+              >
+                {isDeleting ? "Suppression..." : "Confirmer la suppression"}
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowDeleteConfirm(false)}
+                className="text-sm text-gray-500 hover:text-gray-700 underline"
+              >
+                Annuler
+              </button>
+            </div>
+          )}
         </div>
       )}
 
@@ -180,38 +207,6 @@ export default function ProfileEdit() {
           Enregistrer
         </button>
       </form>
-
-      {user.avatar && (
-        <div className="mt-4 text-center">
-          {!showDeleteConfirm ? (
-            <button
-              type="button"
-              onClick={() => setShowDeleteConfirm(true)}
-              className="text-sm text-red-600 hover:text-red-800 underline"
-            >
-              Supprimer l&apos;avatar
-            </button>
-          ) : (
-            <div className="flex items-center justify-center gap-3">
-              <button
-                type="button"
-                onClick={handleDeleteAvatar}
-                disabled={isDeleting}
-                className="text-sm text-white bg-red-600 hover:bg-red-700 px-3 py-1 rounded disabled:opacity-50"
-              >
-                {isDeleting ? "Suppression..." : "Confirmer la suppression"}
-              </button>
-              <button
-                type="button"
-                onClick={() => setShowDeleteConfirm(false)}
-                className="text-sm text-gray-500 hover:text-gray-700 underline"
-              >
-                Annuler
-              </button>
-            </div>
-          )}
-        </div>
-      )}
 
       <div className="mt-6 text-center">
         <Link


### PR DESCRIPTION
## Summary
- Repositionne le bouton "Supprimer l'avatar" directement sous l'avatar en haut de la page d'édition du profil
- Supprime le bloc de suppression qui était placé après le formulaire
- Conserve la confirmation inline (Confirmer / Annuler)

## Test plan
- [ ] Ouvrir la page d'édition du profil avec un avatar existant → le bouton "Supprimer l'avatar" apparaît sous l'avatar
- [ ] Cliquer sur le bouton → la confirmation inline s'affiche
- [ ] Cliquer sur "Annuler" → le bouton initial réapparaît
- [ ] Cliquer sur "Confirmer la suppression" → l'avatar est supprimé et le bouton disparaît
- [ ] Ouvrir la page sans avatar → aucun bouton de suppression affiché

🤖 Generated with [Claude Code](https://claude.com/claude-code)