### PR TITLE
Add post view count tracking and display

### DIFF
--- a/apps/blog/api_views.py
+++ b/apps/blog/api_views.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
-from django.db.models import Q
+from django.db.models import F, Q
 from rest_framework import generics, permissions, status
 from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.response import Response
@@ -137,6 +137,19 @@ class PostDetailAPIView(generics.RetrieveUpdateDestroyAPIView):
                 Q(status=Post.STATUS_PUBLISHED) | Q(author=self.request.user)
             )
         return qs.filter(status=Post.STATUS_PUBLISHED)
+
+    def retrieve(self, request, *args, **kwargs):
+        instance = self.get_object()
+        is_author = (
+            request.user.is_authenticated and instance.author_id == request.user.id
+        )
+        if instance.status == Post.STATUS_PUBLISHED and not is_author:
+            Post.objects.filter(pk=instance.pk).update(
+                view_count=F("view_count") + 1
+            )
+            instance.view_count = (instance.view_count or 0) + 1
+        serializer = self.get_serializer(instance)
+        return Response(serializer.data)
 
     def update(self, request, *args, **kwargs):
         partial = kwargs.pop("partial", False)

--- a/apps/blog/migrations/0010_add_view_count_to_post.py
+++ b/apps/blog/migrations/0010_add_view_count_to_post.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("blog", "0009_add_is_pinned_to_post"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="post",
+            name="view_count",
+            field=models.PositiveIntegerField(default=0),
+        ),
+    ]

--- a/apps/blog/models.py
+++ b/apps/blog/models.py
@@ -176,6 +176,7 @@ class Post(models.Model):
     )
     is_pinned = models.BooleanField(default=False, db_index=True)
     pinned_at = models.DateTimeField(null=True, blank=True)
+    view_count = models.PositiveIntegerField(default=0)
     published_at = models.DateTimeField(null=True, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
 

--- a/apps/blog/serializers.py
+++ b/apps/blog/serializers.py
@@ -50,6 +50,7 @@ class PostListSerializer(serializers.ModelSerializer):
     reading_time_minutes = serializers.SerializerMethodField()
     has_draft = serializers.SerializerMethodField()
     cover_image = serializers.ImageField(read_only=True)
+    view_count = serializers.SerializerMethodField()
 
     class Meta:
         model = Post
@@ -66,10 +67,17 @@ class PostListSerializer(serializers.ModelSerializer):
             "has_draft",
             "is_pinned",
             "pinned_at",
+            "view_count",
             "published_at",
             "created_at",
         )
         read_only_fields = ("is_pinned", "pinned_at")
+
+    def get_view_count(self, obj):
+        request = self.context.get("request")
+        if request and request.user.is_authenticated and request.user.is_superuser:
+            return obj.view_count
+        return None
 
     def get_reading_time_minutes(self, obj):
         """Estime le temps de lecture (en minutes) affiché sur la liste."""
@@ -123,6 +131,7 @@ class PostDetailSerializer(serializers.ModelSerializer):
     draft_title = serializers.SerializerMethodField()
     draft_content = serializers.SerializerMethodField()
     cover_image = serializers.ImageField(read_only=True)
+    view_count = serializers.SerializerMethodField()
 
     class Meta:
         model = Post
@@ -142,6 +151,7 @@ class PostDetailSerializer(serializers.ModelSerializer):
             "draft_content",
             "is_pinned",
             "pinned_at",
+            "view_count",
             "published_at",
             "created_at",
         )
@@ -172,6 +182,12 @@ class PostDetailSerializer(serializers.ModelSerializer):
         if self._is_author(obj):
             return obj.draft_content
         return ""
+
+    def get_view_count(self, obj):
+        request = self.context.get("request")
+        if request and request.user.is_authenticated and request.user.is_superuser:
+            return obj.view_count
+        return None
 
     def get_approved_comments(self, obj):
         comments = (

--- a/apps/blog/tests/test_api.py
+++ b/apps/blog/tests/test_api.py
@@ -1398,3 +1398,85 @@ class TestPostCoverImageAPI:
         assert response.status_code == 200
         post.refresh_from_db()
         assert post.cover_image.url != old_url
+
+
+@pytest.mark.django_db
+class TestPostViewCountAPI:
+    def setup_method(self):
+        self.client = Client()
+
+    def test_view_count_increments_on_anonymous_detail(self):
+        post = PostFactory(view_count=0)
+        self.client.get(api_post_url(post.slug))
+        post.refresh_from_db()
+        assert post.view_count == 1
+
+    def test_view_count_increments_on_non_author_detail(self):
+        post = PostFactory(view_count=0)
+        other = UserFactory()
+        self.client.force_login(other)
+        self.client.get(api_post_url(post.slug))
+        self.client.get(api_post_url(post.slug))
+        post.refresh_from_db()
+        assert post.view_count == 2
+
+    def test_view_count_not_incremented_for_author(self):
+        user = SuperUserFactory()
+        post = PostFactory(author=user, view_count=5)
+        self.client.force_login(user)
+        self.client.get(api_post_url(post.slug))
+        post.refresh_from_db()
+        assert post.view_count == 5
+
+    def test_view_count_not_incremented_on_draft(self):
+        user = SuperUserFactory()
+        post = PostFactory(author=user, status=Post.STATUS_DRAFT, view_count=0)
+        self.client.force_login(user)
+        self.client.get(api_post_url(post.slug))
+        post.refresh_from_db()
+        assert post.view_count == 0
+
+    def test_view_count_visible_to_superuser_in_detail(self):
+        post = PostFactory(view_count=42)
+        admin = SuperUserFactory()
+        self.client.force_login(admin)
+        response = self.client.get(api_post_url(post.slug))
+        # The superuser's own GET triggers one increment.
+        assert response.json()["view_count"] == 43
+
+    def test_view_count_hidden_from_anonymous_in_detail(self):
+        post = PostFactory(view_count=42)
+        response = self.client.get(api_post_url(post.slug))
+        assert response.json()["view_count"] is None
+
+    def test_view_count_hidden_from_regular_user_in_detail(self):
+        post = PostFactory(view_count=42)
+        user = UserFactory()
+        self.client.force_login(user)
+        response = self.client.get(api_post_url(post.slug))
+        assert response.json()["view_count"] is None
+
+    def test_view_count_visible_to_superuser_in_list(self):
+        PostFactory(view_count=7)
+        admin = SuperUserFactory()
+        self.client.force_login(admin)
+        response = self.client.get(API_POSTS_URL)
+        assert response.json()["results"][0]["view_count"] == 7
+
+    def test_view_count_hidden_from_anonymous_in_list(self):
+        PostFactory(view_count=7)
+        response = self.client.get(API_POSTS_URL)
+        assert response.json()["results"][0]["view_count"] is None
+
+    def test_view_count_hidden_from_regular_user_in_list(self):
+        PostFactory(view_count=7)
+        user = UserFactory()
+        self.client.force_login(user)
+        response = self.client.get(API_POSTS_URL)
+        assert response.json()["results"][0]["view_count"] is None
+
+    def test_list_does_not_increment_view_count(self):
+        post = PostFactory(view_count=0)
+        self.client.get(API_POSTS_URL)
+        post.refresh_from_db()
+        assert post.view_count == 0

--- a/frontend/src/components/blog/PostCard.jsx
+++ b/frontend/src/components/blog/PostCard.jsx
@@ -55,6 +55,9 @@ export default function PostCard({ post: initialPost, onChange }) {
   const canEdit =
     user && user.is_superuser && post.author && user.id === post.author.id;
   const canPin = canEdit && post.status === "published";
+  const showViewCount =
+    user && user.is_superuser && post.view_count !== null &&
+    post.view_count !== undefined;
 
   const handleTogglePin = async () => {
     if (pinToggling) return;
@@ -271,6 +274,33 @@ export default function PostCard({ post: initialPost, onChange }) {
               title="Brouillon en cours"
             >
               Brouillon en cours
+            </span>
+          )}
+          {showViewCount && (
+            <span
+              className="inline-flex items-center gap-1 text-[10px] tracking-[1.4px] uppercase font-semibold text-editorial-dim"
+              title={`${post.view_count} vue${post.view_count > 1 ? "s" : ""}`}
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.6}
+                stroke="currentColor"
+                className="size-3"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z"
+                />
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+                />
+              </svg>
+              {post.view_count} {post.view_count > 1 ? "vues" : "vue"}
             </span>
           )}
         </div>

--- a/frontend/src/components/blog/PostDetail.jsx
+++ b/frontend/src/components/blog/PostDetail.jsx
@@ -367,6 +367,10 @@ export default function PostDetail() {
   const readingMinutes = post.reading_time_minutes;
   const isOwnerSuperuser = post.is_owner && user?.is_superuser;
   const hasDraftChanges = post.status === "published" && post.has_draft;
+  const showViewCount =
+    user?.is_superuser &&
+    post.view_count !== null &&
+    post.view_count !== undefined;
 
   return (
     <div className="bg-editorial-paper">
@@ -437,6 +441,11 @@ export default function PostDetail() {
                     year: "numeric",
                   })}
                   {readingMinutes ? ` · ${readingMinutes} min de lecture` : ""}
+                  {showViewCount
+                    ? ` · ${post.view_count} ${
+                        post.view_count > 1 ? "vues" : "vue"
+                      }`
+                    : ""}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
This PR adds view count tracking functionality to blog posts, allowing administrators to see how many times a post has been viewed while keeping this metric hidden from regular users and anonymous visitors.

## Key Changes
- **Database**: Added `view_count` field to the Post model with a migration
- **API**: 
  - Modified `PostDetailView.retrieve()` to increment view count when published posts are accessed by non-authors
  - Added `view_count` serializer method field to both `PostListSerializer` and `PostDetailSerializer` that only exposes the count to authenticated superusers
- **Frontend**:
  - Updated `PostCard` component to display view count badge for superusers only
  - Updated `PostDetail` component to show view count in the post metadata for superusers only
  - Added conditional rendering logic to check user permissions and null/undefined values

## Implementation Details
- View count increments only for published posts accessed by non-authors (anonymous users and regular authenticated users)
- Authors viewing their own posts do not trigger view count increments
- Draft posts never increment view count
- View count is hidden from non-superuser responses via serializer method fields
- Frontend displays view count with an eye icon and proper French pluralization ("vue" vs "vues")
- Uses Django's `F()` expression for atomic database increment to avoid race conditions

https://claude.ai/code/session_014FhbU6MLNvDBtWVpVqjRmY