### PR TITLE
fix(blog): remove blue focus border on BlockNote editor on Firefox

### DIFF
--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -127,9 +127,18 @@
   padding-left: 0 !important;
 }
 
+.bn-container:focus,
+.bn-container:focus-visible,
+.bn-container:focus-within,
+.bn-editor:focus,
+.bn-editor:focus-visible,
+.bn-editor:focus-within,
 .bn-editor .ProseMirror:focus,
-.bn-editor .ProseMirror:focus-visible {
+.bn-editor .ProseMirror:focus-visible,
+.bn-editor [contenteditable]:focus,
+.bn-editor [contenteditable]:focus-visible {
   outline: none !important;
+  box-shadow: none !important;
 }
 
 /* Article prose — editorial typography for rendered BlockNote content */


### PR DESCRIPTION
## Résumé

- Élargit la règle de reset de focus de l'éditeur BlockNote aux wrappers (`.bn-container`, `.bn-editor`) et à tout `[contenteditable]` enfant.
- Supprime aussi `box-shadow` (Mantine utilise `box-shadow` pour ses focus rings, ce qui expliquait la "bordure bleue" sous Firefox).

## Test plan

- [x] Vérifier sur Firefox que la bordure bleue disparaît à la saisie dans un article (création et édition).
- [x] Re-vérifier qu'aucun focus ring légitime n'est cassé ailleurs dans l'app (formulaires hors éditeur).

Fixes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)