### PR TITLE
fix(blog): make BlockNote editor background transparent

### DIFF
--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -123,6 +123,12 @@
 }
 
 /* BlockNote editor overrides */
+.bn-container,
+.bn-editor,
+.bn-editor .ProseMirror {
+  background: transparent !important;
+}
+
 .bn-editor {
   padding-left: 0 !important;
 }


### PR DESCRIPTION
## Résumé

- Force `background: transparent` sur `.bn-container`, `.bn-editor` et `.ProseMirror` pour neutraliser le fond blanc par défaut de `@blocknote/mantine`.
- L'éditeur hérite maintenant du fond `editorial-paper` de la page, cohérent avec le reste de l'app.

## Test plan

- [x] Vérifier sur la page de création/édition d'article que l'éditeur n'a plus de fond blanc et prend la teinte de la page.
- [ ] Vérifier en mode sombre (`.dark`) que le fond hérité reste correct.

Fixes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)