### PR TITLE
chore(skills): ajouter une phase 0 de sync du repo local

### DIFF
--- a/.claude/skills/create-github-issue/SKILL.md
+++ b/.claude/skills/create-github-issue/SKILL.md
@@ -51,6 +51,18 @@ Helpful read-only tools to prepare the issue:
 
 Follow these phases in order. Keep each one short — the goal is a good ticket, not a novel.
 
+### 0. Sync local repo
+
+If you'll anchor the issue on `file:line` references (see step 2), make sure the local checkout is up to date first so the cited lines match what reviewers will see.
+
+1. Detect the default branch: `DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')`.
+2. Fetch: `git fetch origin`.
+3. If the current branch **is** the default branch: `git pull --ff-only`.
+4. Otherwise, stay on the current branch — the fetch is enough.
+5. If `pull --ff-only` fails (local commits on the default branch), **stop and ask the user** — never merge or rebase silently.
+
+If the cwd is not a git repo (e.g. the user is drafting a ticket outside a repo), skip this phase.
+
 ### 1. Capture the user's intent
 
 Summarize back to the user in one sentence:

--- a/.claude/skills/implement-github-issue/SKILL.md
+++ b/.claude/skills/implement-github-issue/SKILL.md
@@ -35,6 +35,18 @@ Use the GitHub MCP tools. Do not attempt to use `gh` CLI. Key tools:
 
 Follow these phases **in order**. Do not skip phases without the user's agreement.
 
+### 0. Sync local repo
+
+Before anything else, make sure the local checkout is up to date so exploration (Phase 2), planning (Phase 3) and branching (Phase 4) all start from current `main`/`master`.
+
+1. Detect the default branch: `DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')`.
+2. Fetch: `git fetch origin`.
+3. If the current branch **is** the default branch: `git pull --ff-only`.
+4. If the current branch is a feature branch (e.g. the user is resuming a session on a branch they already created), **stay on it** — do not switch. The fetch is enough for later branching off an up-to-date `origin/<default>`.
+5. If `pull --ff-only` fails (local commits on the default branch), **stop and ask the user** — never merge or rebase silently.
+
+If the cwd is not a git repo, skip this phase.
+
 ### 1. Load the issue
 
 Always start here. Never implement from memory of the issue.


### PR DESCRIPTION
## Summary

- Ajoute une **Phase 0 — Sync local repo** au début des skills `create-github-issue` et `implement-github-issue`.
- Chaque skill commence maintenant par `git fetch origin` et, si on est sur la branche par défaut, un `git pull --ff-only`.
- Si `pull --ff-only` échoue (commits locaux inattendus sur `main`), le skill stoppe et demande à l'utilisateur — pas de merge/rebase silencieux.
- Si on est sur une feature branch, on y reste : le fetch suffit pour brancher plus tard sur un `origin/<default>` à jour.

## Pourquoi

Avant ce changement, `implement-github-issue` ne faisait aucun pull — la mise à jour de `main` n'arrivait qu'implicitement en Phase 4 (création de branche). Résultat : l'exploration (Phase 2) et le plan (Phase 3) pouvaient se faire sur du code obsolète, et la branche créée partait potentiellement d'un `main` en retard.

Pour `create-github-issue`, l'intérêt est plus ciblé : les ancrages `file:line` dans le body de l'issue correspondent à ce que les reviewers verront sur GitHub.

## Test plan

- [ ] Déclencher `create-github-issue` depuis un checkout à jour → Phase 0 s'exécute sans erreur.
- [ ] Déclencher `implement-github-issue` depuis `main` en retard → `git pull --ff-only` ramène la branche à jour.
- [ ] Déclencher un skill depuis une feature branch → Phase 0 fetch mais ne switch pas.
- [ ] Simuler un commit local inattendu sur `main` → le skill stoppe et demande à l'utilisateur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)