### PR TITLE
Refactor ArticleToc component to use Tailwind CSS and React state

### DIFF
--- a/frontend/src/components/blog/ArticleToc.jsx
+++ b/frontend/src/components/blog/ArticleToc.jsx
@@ -1,12 +1,6 @@
-const INDENT_BY_LEVEL = { 1: 0, 2: 12, 3: 24 };
+import { useState } from "react";
 
-const SUMMARY_LABEL_STYLE = {
-  fontSize: 11,
-  fontWeight: 600,
-  letterSpacing: 2,
-  textTransform: "uppercase",
-  color: "rgb(var(--color-editorial-dim))",
-};
+const INDENT_BY_LEVEL = { 1: "pl-0", 2: "pl-3", 3: "pl-6" };
 
 function Chevron() {
   return (
@@ -20,8 +14,7 @@ function Chevron() {
       strokeLinecap="round"
       strokeLinejoin="round"
       aria-hidden="true"
-      style={{ transition: "transform 150ms ease" }}
-      className="article-toc-chevron"
+      className="article-toc-chevron transition-transform duration-150"
     >
       <path d="m3 4.5 3 3 3-3" />
     </svg>
@@ -29,14 +22,15 @@ function Chevron() {
 }
 
 export default function ArticleToc({ items, collapsible = false }) {
+  const [open, setOpen] = useState(true);
+
   if (!Array.isArray(items) || items.length < 2) return null;
 
   const handleClick = (event, id) => {
     event.preventDefault();
     const target = document.getElementById(id);
     if (!target) return;
-    const details = event.currentTarget.closest("details");
-    if (details) details.open = false;
+    if (collapsible) setOpen(false);
     target.scrollIntoView({ behavior: "smooth", block: "start" });
     if (window.history?.replaceState) {
       window.history.replaceState(null, "", `#${id}`);
@@ -44,34 +38,20 @@ export default function ArticleToc({ items, collapsible = false }) {
   };
 
   const list = (
-    <ol style={{ listStyle: "none", padding: 0, margin: 0 }}>
+    <ol className="list-none p-0 m-0">
       {items.map((item) => (
         <li
           key={item.id}
-          style={{
-            paddingLeft: INDENT_BY_LEVEL[item.level] ?? 0,
-            lineHeight: 1.5,
-            margin: "4px 0",
-          }}
+          className={`${INDENT_BY_LEVEL[item.level] ?? "pl-0"} my-1 leading-6`}
         >
           <a
             href={`#${item.id}`}
             onClick={(event) => handleClick(event, item.id)}
-            style={{
-              fontSize: item.level === 1 ? 14 : 13,
-              fontWeight: item.level === 1 ? 500 : 400,
-              color: "rgb(var(--color-editorial-ink2))",
-              textDecoration: "none",
-              borderBottom: "1px solid transparent",
-              transition: "border-color 120ms ease, color 120ms ease",
-            }}
-            onMouseEnter={(event) => {
-              event.currentTarget.style.borderBottomColor =
-                "rgb(var(--color-editorial-ink2))";
-            }}
-            onMouseLeave={(event) => {
-              event.currentTarget.style.borderBottomColor = "transparent";
-            }}
+            className={`article-toc-link no-underline text-editorial-ink2 ${
+              item.level === 1
+                ? "text-sm font-medium"
+                : "text-[13px] font-normal"
+            }`}
           >
             {item.text}
           </a>
@@ -83,32 +63,18 @@ export default function ArticleToc({ items, collapsible = false }) {
   if (collapsible) {
     return (
       <details
-        className="article-toc-details"
-        open
-        style={{
-          fontFamily: '"Inter", system-ui, sans-serif',
-          border: "1px solid rgb(var(--color-editorial-rule))",
-          borderRadius: 3,
-          padding: "14px 18px",
-          background: "rgb(var(--color-editorial-card))",
-        }}
+        className="article-toc-details font-sans border border-editorial-rule rounded-[3px] px-[18px] py-[14px] bg-editorial-card"
+        open={open}
+        onToggle={(event) => setOpen(event.currentTarget.open)}
       >
         <summary
-          style={{
-            ...SUMMARY_LABEL_STYLE,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            gap: 8,
-            cursor: "pointer",
-            listStyle: "none",
-          }}
+          className="article-toc-label flex items-center justify-between gap-2 cursor-pointer list-none"
           aria-label="Sommaire de l'article"
         >
           <span>Sommaire</span>
           <Chevron />
         </summary>
-        <div style={{ marginTop: 12 }}>{list}</div>
+        <div className="mt-3">{list}</div>
       </details>
     );
   }
@@ -116,14 +82,9 @@ export default function ArticleToc({ items, collapsible = false }) {
   return (
     <nav
       aria-label="Sommaire de l'article"
-      style={{
-        fontFamily: '"Inter", system-ui, sans-serif',
-        margin: "0 0 40px",
-        padding: "20px 0",
-        background: "rgb(var(--color-editorial-paper))",
-      }}
+      className="font-sans my-0 mb-10 py-5 bg-editorial-paper"
     >
-      <h2 style={{ ...SUMMARY_LABEL_STYLE, margin: "0 0 14px" }}>Sommaire</h2>
+      <h2 className="article-toc-label mt-0 mb-[14px]">Sommaire</h2>
       {list}
     </nav>
   );

--- a/frontend/src/components/blog/PostDetail.jsx
+++ b/frontend/src/components/blog/PostDetail.jsx
@@ -524,11 +524,9 @@ export default function PostDetail() {
                 paddingTop: 0,
               }}
             >
-              {headings.length >= 2 && (
-                <div className="hidden lg:block lg:sticky lg:top-[68px]">
-                  <ArticleToc items={headings} />
-                </div>
-              )}
+              <div className="hidden lg:block lg:sticky lg:top-[68px]">
+                <ArticleToc items={headings} />
+              </div>
               <div className="border-t border-editorial-rule lg:border-t-0 pt-12 lg:pt-0">
                 <CommentForm
                   slug={post.slug}

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -90,6 +90,35 @@
   .article-toc-details[open] > summary .article-toc-chevron {
     transform: rotate(180deg);
   }
+
+  .article-toc-label {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    color: rgb(var(--color-editorial-dim));
+  }
+
+  .article-toc-link {
+    border-bottom: 1px solid transparent;
+    transition:
+      border-color 120ms ease,
+      color 120ms ease;
+  }
+
+  .article-toc-link:hover {
+    border-bottom-color: rgb(var(--color-editorial-ink2));
+  }
+
+  .article-toc-link:focus {
+    outline: none;
+  }
+
+  .article-toc-link:focus-visible {
+    outline: 2px solid rgb(var(--color-editorial-accent));
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
 }
 
 @layer components {
@@ -149,6 +178,13 @@
   padding-left: 0 !important;
 }
 
+/*
+ * Supprime le focus ring Firefox (box-shadow + outline) sur tous les wrappers
+ * BlockNote et leurs [contenteditable]. Le reset est volontairement large pour
+ * couvrir les futures variantes de markup BlockNote/Mantine. Si une MAJ
+ * introduit un focus ring légitime (ex. toolbar accessibilité), restreindre
+ * ici plutôt que d'empiler des surcharges ailleurs.
+ */
 .bn-container:focus,
 .bn-container:focus-visible,
 .bn-container:focus-within,


### PR DESCRIPTION
## Summary
Refactored the `ArticleToc` component to use Tailwind CSS utility classes instead of inline styles, and replaced DOM manipulation with React state management for the collapsible details element.

## Key Changes

- **Styling Migration**: Converted all inline `style` objects to Tailwind CSS classes throughout the component
  - Indent levels now use Tailwind padding utilities (`pl-0`, `pl-3`, `pl-6`)
  - Spacing, typography, and layout properties moved to className attributes
  - Chevron animation now uses `transition-transform duration-150` instead of inline style

- **State Management**: Replaced DOM-based details element control with React `useState`
  - Added `open` state to track collapsible details element
  - Replaced `details.open = false` DOM manipulation with `setOpen(false)`
  - Added `onToggle` handler to sync details element state with React state

- **CSS Organization**: Extracted reusable styles to `index.css`
  - Created `.article-toc-label` class for summary label styling (font size, weight, letter-spacing, text-transform, color)
  - Created `.article-toc-link` class with hover and focus-visible states for better accessibility
  - Moved transition and hover effects from inline handlers to CSS

- **Accessibility Improvements**: Enhanced focus management
  - Added `focus-visible` outline styling for keyboard navigation
  - Removed inline `onMouseEnter`/`onMouseLeave` handlers in favor of CSS `:hover` pseudo-class

- **Minor Cleanup**: Removed unnecessary conditional rendering in `PostDetail.jsx` for the ArticleToc wrapper div

## Implementation Details

The component now properly manages the collapsible state through React rather than direct DOM manipulation, making it more predictable and testable. The styling refactor reduces the component file size and improves maintainability by centralizing style definitions in the CSS layer.

https://claude.ai/code/session_01Vf8Rct1gyc6XJ3GN4b13fj