### PR TITLE
Add draft publishing capability to blog post editor

### DIFF
--- a/frontend/src/components/blog/PostForm.jsx
+++ b/frontend/src/components/blog/PostForm.jsx
@@ -116,7 +116,9 @@ export default function PostForm() {
   const [coverImageUploading, setCoverImageUploading] = useState(false);
   const [isPinned, setIsPinned] = useState(false);
   const [postStatus, setPostStatus] = useState("");
+  const [hasDraft, setHasDraft] = useState(false);
   const [pinToggling, setPinToggling] = useState(false);
+  const [publishing, setPublishing] = useState(false);
   const coverImageFileRef = useRef(null);
   const coverBlobUrlRef = useRef(null);
   const titleRef = useRef(null);
@@ -153,6 +155,7 @@ export default function PostForm() {
           }
           setIsPinned(Boolean(res.data.is_pinned));
           setPostStatus(res.data.status || "");
+          setHasDraft(Boolean(res.data.has_draft));
           try {
             const parsed = JSON.parse(editContent);
             setInitialContent(parsed);
@@ -194,7 +197,7 @@ export default function PostForm() {
   };
 
   const performAutosave = useCallback(async () => {
-    if (!slug || isSavingRef.current) return;
+    if (!slug || isSavingRef.current) return true;
 
     const currentTitle = titleValueRef.current;
     const currentContent = editorRef.current
@@ -210,7 +213,7 @@ export default function PostForm() {
       JSON.stringify(currentTags) === JSON.stringify(lastSavedTagsRef.current)
     ) {
       isDirtyRef.current = false;
-      return;
+      return true;
     }
 
     isSavingRef.current = true;
@@ -235,6 +238,8 @@ export default function PostForm() {
         now.toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" })
       );
       setSaveStatus("saved");
+      setHasDraft(true);
+      return true;
     } else {
       setSaveStatus("error");
       isDirtyRef.current = true;
@@ -245,6 +250,7 @@ export default function PostForm() {
           performAutosave();
         }, 5000);
       }
+      return false;
     }
   }, [slug]);
 
@@ -415,6 +421,48 @@ export default function PostForm() {
     if (res.ok) {
       setCoverImage(null);
     }
+  };
+
+  const handlePublishFromEdit = async () => {
+    if (!slug || publishing) return;
+    setErrors({});
+
+    if (!titleValueRef.current.trim()) {
+      setErrors({ title: ["Le titre est obligatoire."] });
+      return;
+    }
+
+    // Cancel any pending autosave timer and flush dirty content before publishing
+    if (autosaveTimerRef.current) {
+      clearTimeout(autosaveTimerRef.current);
+      autosaveTimerRef.current = null;
+    }
+    if (isDirtyRef.current) {
+      const saved = await performAutosave();
+      if (!saved) {
+        setErrors({
+          non_field_errors: [
+            "Impossible de sauvegarder les modifications avant publication. Veuillez réessayer.",
+          ],
+        });
+        return;
+      }
+    }
+
+    setPublishing(true);
+    const res = await api.post(`/api/blog/posts/${slug}/publish/`);
+    if (res.ok) {
+      isDirtyRef.current = false;
+      setPublishing(false);
+      navigate(`/articles/${res.data.slug}`);
+      return;
+    }
+    setPublishing(false);
+    const errorMessage =
+      res.errors?.error ||
+      res.errors?.detail ||
+      "Erreur lors de la publication.";
+    setErrors({ non_field_errors: [errorMessage] });
   };
 
   const handleSubmit = async (e, { publish = false } = {}) => {
@@ -698,6 +746,26 @@ export default function PostForm() {
             </button>
           </div>
         )}
+
+        {isEdit &&
+          (postStatus === "draft" ||
+            (postStatus === "published" && hasDraft)) && (
+            <div className="flex gap-3 mt-8">
+              <button
+                type="button"
+                onClick={handlePublishFromEdit}
+                disabled={publishing}
+                className="btn-primary flex-1 py-3"
+                style={{ opacity: publishing ? 0.6 : 1 }}
+              >
+                {publishing
+                  ? "Publication…"
+                  : postStatus === "published"
+                    ? "Publier les modifications"
+                    : "Publier"}
+              </button>
+            </div>
+          )}
       </form>
 
       <div className="mt-10 pt-6 border-t border-editorial-rule">


### PR DESCRIPTION
## Summary
This PR adds the ability to publish draft posts and draft changes directly from the post editor, improving the workflow for content creators.

## Key Changes
- **New state management**: Added `hasDraft` and `publishing` state variables to track draft status and publishing operations
- **Enhanced autosave**: Modified `performAutosave()` to return a boolean indicating success/failure and set `hasDraft` to true when drafts are saved
- **New publish handler**: Implemented `handlePublishFromEdit()` function that:
  - Validates required fields (title)
  - Flushes any pending autosave operations before publishing
  - Calls the `/api/blog/posts/{slug}/publish/` endpoint
  - Handles errors gracefully with user-friendly messages
  - Redirects to the published article on success
- **UI updates**: Added a conditional publish button in edit mode that appears when:
  - Post status is "draft", OR
  - Post status is "published" AND there are unsaved draft changes
  - Button text dynamically changes based on context ("Publier" vs "Publier les modifications")
- **Draft tracking**: The `hasDraft` flag is now populated from the API response and updated when autosave completes

## Implementation Details
- The publish operation ensures all dirty content is saved before publishing by awaiting `performAutosave()`
- Publishing is disabled during the operation to prevent duplicate submissions
- The autosave timer is cleared before publishing to avoid race conditions
- Error handling provides specific feedback when autosave fails before publishing

https://claude.ai/code/session_01NWMcYfzPEf6VzHgJmuioPU