### PR TITLE
feat(blog): sticky OwnerActions bar on editable article

### DIFF
--- a/frontend/src/components/blog/PostDetail.jsx
+++ b/frontend/src/components/blog/PostDetail.jsx
@@ -240,6 +240,10 @@ function OwnerActions({
         borderTop: "1px solid rgb(var(--color-editorial-rule))",
         borderBottom: "1px solid rgb(var(--color-editorial-rule))",
         margin: "28px 0",
+        position: "sticky",
+        top: 68,
+        zIndex: 9,
+        background: "rgb(var(--color-editorial-paper))",
       }}
     >
       <span


### PR DESCRIPTION
## Summary
- Rend la barre `OwnerActions` (Modifier, Publier, Épingler, Versions, Supprimer) `position: sticky` sur la page de détail d'un article, visible uniquement pour le propriétaire superuser.
- Offset `top: 68px` aligné sur la TOC latérale existante ; `z-index: 9` sous le header (`z-10`) ; fond `--color-editorial-paper` pour masquer le contenu qui scrolle derrière.

## Test plan
- [ ] Ouvrir un article publié en tant qu'auteur superuser, scroller : la barre reste collée sous le header.
- [ ] Même vérification sur un brouillon (`status=draft`) du même auteur.
- [ ] Ouvrir le même article en mode anonyme / non-propriétaire : aucune barre, aucun changement.
- [ ] Sur viewport mobile (≤ 768px) : la barre reste sticky et ne casse pas son wrapping.
- [ ] Sur viewport desktop (≥ 1024px) : pas de chevauchement avec la TOC sticky dans la sidebar ni avec le header.

Fixes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)