### PR TITLE
refactor(blog): extract LinkedInShareButton and add tests

### DIFF
--- a/frontend/src/components/blog/LinkedInShareButton.jsx
+++ b/frontend/src/components/blog/LinkedInShareButton.jsx
@@ -1,0 +1,63 @@
+export default function LinkedInShareButton({ title, status }) {
+  if (status !== "published") return null;
+
+  const shareUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(
+    window.location.origin + window.location.pathname,
+  )}`;
+
+  return (
+    <div
+      style={{
+        marginTop: 56,
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+        flexWrap: "wrap",
+        fontFamily: '"Inter", system-ui, sans-serif',
+      }}
+    >
+      <span
+        style={{
+          fontSize: 11,
+          color: "rgb(var(--color-editorial-dim))",
+          textTransform: "uppercase",
+          letterSpacing: 1,
+          fontWeight: 500,
+        }}
+      >
+        Partager
+      </span>
+      <a
+        href={shareUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={`Partager « ${title} » sur LinkedIn`}
+        title="Partager sur LinkedIn"
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 6,
+          fontSize: 12,
+          fontWeight: 500,
+          padding: "6px 10px",
+          borderRadius: 3,
+          textDecoration: "none",
+          border: "1px solid rgb(var(--color-editorial-rule))",
+          background: "rgb(var(--color-editorial-card))",
+          color: "rgb(var(--color-editorial-text))",
+        }}
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.852 3.37-1.852 3.601 0 4.267 2.37 4.267 5.455v6.288zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.063 2.063 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+        </svg>
+        <span>LinkedIn</span>
+      </a>
+    </div>
+  );
+}

--- a/frontend/src/components/blog/LinkedInShareButton.test.jsx
+++ b/frontend/src/components/blog/LinkedInShareButton.test.jsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import LinkedInShareButton from "./LinkedInShareButton";
+
+describe("LinkedInShareButton", () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    delete window.location;
+    window.location = {
+      ...originalLocation,
+      origin: "https://blog.example.com",
+      pathname: "/articles/mon-titre",
+    };
+  });
+
+  afterEach(() => {
+    window.location = originalLocation;
+  });
+
+  it("renders nothing when status is not 'published'", () => {
+    const { container } = render(
+      <LinkedInShareButton title="Mon titre" status="draft" />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the share link when status is 'published'", () => {
+    render(<LinkedInShareButton title="Mon titre" status="published" />);
+    expect(
+      screen.getByRole("link", { name: /partager .* sur linkedin/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("builds the share URL from window.location.origin + pathname", () => {
+    render(<LinkedInShareButton title="Mon titre" status="published" />);
+    const link = screen.getByRole("link", { name: /partager .* sur linkedin/i });
+
+    const expectedTarget = encodeURIComponent(
+      "https://blog.example.com/articles/mon-titre",
+    );
+    expect(link).toHaveAttribute(
+      "href",
+      `https://www.linkedin.com/sharing/share-offsite/?url=${expectedTarget}`,
+    );
+  });
+
+  it("includes the title in the aria-label", () => {
+    render(
+      <LinkedInShareButton title="Article génial" status="published" />,
+    );
+    const link = screen.getByRole("link", { name: /partager .* sur linkedin/i });
+    expect(link).toHaveAttribute(
+      "aria-label",
+      "Partager « Article génial » sur LinkedIn",
+    );
+  });
+
+  it("opens the link in a new tab with safe rel attributes", () => {
+    render(<LinkedInShareButton title="Mon titre" status="published" />);
+    const link = screen.getByRole("link", { name: /partager .* sur linkedin/i });
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+});

--- a/frontend/src/components/blog/PostDetail.jsx
+++ b/frontend/src/components/blog/PostDetail.jsx
@@ -13,6 +13,7 @@ import { buildHeadingIndex } from "../../utils/articleToc";
 import ArticleToc from "./ArticleToc";
 import CommentForm from "./CommentForm";
 import CommentSection from "./CommentSection";
+import LinkedInShareButton from "./LinkedInShareButton";
 
 function BlockNoteRenderer({ content, onHeadings }) {
   const blocks = useMemo(() => {
@@ -107,69 +108,6 @@ function AuthorAvatar({ user, size = 36 }) {
       }}
     >
       {initial}
-    </div>
-  );
-}
-
-function LinkedInShareButton({ title }) {
-  const shareUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(
-    window.location.origin + window.location.pathname,
-  )}`;
-
-  return (
-    <div
-      style={{
-        marginTop: 56,
-        display: "flex",
-        alignItems: "center",
-        gap: 12,
-        flexWrap: "wrap",
-        fontFamily: '"Inter", system-ui, sans-serif',
-      }}
-    >
-      <span
-        style={{
-          fontSize: 11,
-          color: "rgb(var(--color-editorial-dim))",
-          textTransform: "uppercase",
-          letterSpacing: 1,
-          fontWeight: 500,
-        }}
-      >
-        Partager
-      </span>
-      <a
-        href={shareUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        aria-label={`Partager « ${title} » sur LinkedIn`}
-        title="Partager sur LinkedIn"
-        style={{
-          display: "inline-flex",
-          alignItems: "center",
-          gap: 6,
-          fontSize: 12,
-          fontWeight: 500,
-          padding: "6px 10px",
-          borderRadius: 3,
-          textDecoration: "none",
-          border: "1px solid rgb(var(--color-editorial-rule))",
-          background: "rgb(var(--color-editorial-card))",
-          color: "rgb(var(--color-editorial-text))",
-          transition: "background-color 120ms ease, border-color 120ms ease",
-        }}
-      >
-        <svg
-          width="14"
-          height="14"
-          viewBox="0 0 24 24"
-          fill="currentColor"
-          aria-hidden="true"
-        >
-          <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.852 3.37-1.852 3.601 0 4.267 2.37 4.267 5.455v6.288zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.063 2.063 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
-        </svg>
-        <span>LinkedIn</span>
-      </a>
     </div>
   );
 }
@@ -566,9 +504,7 @@ export default function PostDetail() {
               onHeadings={setHeadings}
             />
 
-            {post.status === "published" && (
-              <LinkedInShareButton title={displayTitle} />
-            )}
+            <LinkedInShareButton title={displayTitle} status={post.status} />
 
             <div
               className="mt-14 pt-6"


### PR DESCRIPTION
## Summary

- Extracts `LinkedInShareButton` from `PostDetail.jsx` into its own file (`frontend/src/components/blog/LinkedInShareButton.jsx`) — `PostDetail.jsx` is now under 600 lines.
- Removes the dead inline `transition` declaration: inline styles cannot react to `:hover`/`:focus`, so the transition was never observable.
- Moves the `post.status === "published"` guard into the component (returns `null` otherwise), making the conditional behavior testable in isolation.
- Adds Vitest + Testing Library coverage for the component:
  - returns nothing when `status !== "published"`
  - builds the share URL from `window.location.origin + pathname`
  - exposes the title via `aria-label`
  - sets `target="_blank"` + `rel="noopener noreferrer"`

Out of scope (kept for follow-up — see #256):
- Centralizing the hardcoded typography/colors in Tailwind/CSS variables.
- Generic `ShareButtons` component for additional channels.

Closes #256

## Test plan

- [x] `cd frontend && npm test` — 18 tests pass (13 existing + 5 new)
- [x] `cd frontend && npm run build` — production build OK
- [ ] Manual visual check on a published article (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)