### PR TITLE
refactor(blog): extract OwnerActions, scope sticky to md+, add tests

### DIFF
--- a/frontend/src/components/blog/OwnerActions.jsx
+++ b/frontend/src/components/blog/OwnerActions.jsx
@@ -1,0 +1,164 @@
+import { Link } from "react-router-dom";
+
+function OwnerIcon({ d, filled = false }) {
+  return (
+    <svg
+      width="13"
+      height="13"
+      viewBox="0 0 24 24"
+      fill={filled ? "currentColor" : "none"}
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d={d} />
+    </svg>
+  );
+}
+
+export default function OwnerActions({
+  post,
+  user,
+  publishing,
+  onPublish,
+  pinToggling,
+  onTogglePin,
+  hasVersions,
+  hasDraftChanges,
+}) {
+  if (!post?.is_owner || !user?.is_superuser) return null;
+
+  const base = {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 6,
+    fontFamily: '"Inter", system-ui, sans-serif',
+    fontSize: 12,
+    fontWeight: 500,
+    padding: "6px 10px",
+    borderRadius: 3,
+    cursor: "pointer",
+    whiteSpace: "nowrap",
+    textDecoration: "none",
+  };
+  const neutral = {
+    ...base,
+    border: "1px solid rgb(var(--color-editorial-rule))",
+    background: "rgb(var(--color-editorial-card))",
+    color: "rgb(var(--color-editorial-text))",
+  };
+  const primary = {
+    ...base,
+    border: "1px solid rgb(var(--color-editorial-ink))",
+    background: "rgb(var(--color-editorial-ink))",
+    color: "rgb(var(--color-editorial-paper))",
+  };
+  const canPublishDraft = post.status === "draft";
+  const canPublishChanges = post.status === "published" && post.has_draft;
+
+  return (
+    <div
+      data-testid="owner-actions"
+      className="md:sticky md:top-[var(--header-height)] md:z-[var(--z-owner-actions)]"
+      style={{
+        display: "flex",
+        gap: 6,
+        flexWrap: "wrap",
+        alignItems: "center",
+        padding: "10px 0",
+        borderTop: "1px solid rgb(var(--color-editorial-rule))",
+        borderBottom: "1px solid rgb(var(--color-editorial-rule))",
+        margin: "28px 0",
+        background: "rgb(var(--color-editorial-paper))",
+      }}
+    >
+      <span
+        style={{
+          fontFamily: '"Inter", system-ui, sans-serif',
+          fontSize: 11,
+          color: "rgb(var(--color-editorial-dim))",
+          textTransform: "uppercase",
+          letterSpacing: 1,
+          fontWeight: 500,
+          alignSelf: "center",
+          marginRight: 8,
+        }}
+      >
+        Auteur
+      </span>
+
+      <Link to={`/articles/${post.slug}/modifier`} style={neutral} title="Modifier">
+        <OwnerIcon d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Z" />
+        <span>Modifier</span>
+      </Link>
+
+      {(canPublishDraft || canPublishChanges) && (
+        <button
+          type="button"
+          onClick={onPublish}
+          disabled={publishing}
+          style={{ ...primary, opacity: publishing ? 0.6 : 1 }}
+          title={canPublishChanges ? "Publier les modifications" : "Publier"}
+        >
+          <OwnerIcon d="M12 19.5v-15m0 0-6.75 6.75M12 4.5l6.75 6.75" />
+          <span>
+            {publishing
+              ? "Publication…"
+              : canPublishChanges
+                ? "Publier les modifications"
+                : "Publier"}
+          </span>
+        </button>
+      )}
+
+      {post.status === "published" && (
+        <button
+          type="button"
+          onClick={onTogglePin}
+          disabled={pinToggling}
+          style={{ ...neutral, opacity: pinToggling ? 0.6 : 1 }}
+          title={post.is_pinned ? "Désépingler" : "Épingler à la une"}
+        >
+          <OwnerIcon
+            d="M9 4.5v4.5l-3 3v2.25h12V12l-3-3V4.5m-6 9v6"
+            filled={post.is_pinned}
+          />
+          <span>{post.is_pinned ? "Désépingler" : "Épingler"}</span>
+        </button>
+      )}
+
+      {hasVersions && (
+        <Link to={`/articles/${post.slug}/versions`} style={neutral} title="Versions">
+          <OwnerIcon d="M12 6v6h4.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+          <span>Versions</span>
+        </Link>
+      )}
+
+      <Link
+        to={`/articles/${post.slug}/supprimer`}
+        style={neutral}
+        title="Supprimer"
+      >
+        <OwnerIcon d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0c.342.052.682.107 1.022.166m-16.5-.165c.34-.059.68-.114 1.022-.165m14.456 0a48.108 48.108 0 0 0-3.478-.397M5.794 5.625a48.11 48.11 0 0 1 3.478-.397M15.272 5.228v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916" />
+        <span>Supprimer</span>
+      </Link>
+
+      <div style={{ flex: 1 }} />
+
+      {hasDraftChanges && (
+        <span
+          style={{
+            fontFamily: '"Inter", system-ui, sans-serif',
+            fontSize: 11,
+            color: "rgb(var(--color-editorial-accent))",
+            alignSelf: "center",
+            fontStyle: "italic",
+          }}
+        >
+          Modifications non publiées
+        </span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/blog/OwnerActions.test.jsx
+++ b/frontend/src/components/blog/OwnerActions.test.jsx
@@ -1,0 +1,102 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+
+import OwnerActions from "./OwnerActions";
+
+const renderWithRouter = (ui) =>
+  render(<MemoryRouter>{ui}</MemoryRouter>);
+
+const basePost = {
+  slug: "mon-article",
+  status: "published",
+  is_owner: true,
+  is_pinned: false,
+  has_draft: false,
+};
+
+const baseProps = {
+  publishing: false,
+  onPublish: () => {},
+  pinToggling: false,
+  onTogglePin: () => {},
+  hasVersions: false,
+  hasDraftChanges: false,
+};
+
+describe("OwnerActions", () => {
+  it("renders nothing when the user is anonymous", () => {
+    const { container } = renderWithRouter(
+      <OwnerActions post={basePost} user={null} {...baseProps} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when the user is the owner but not a superuser", () => {
+    const { container } = renderWithRouter(
+      <OwnerActions
+        post={basePost}
+        user={{ is_superuser: false }}
+        {...baseProps}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when the user is a superuser but not the owner", () => {
+    const { container } = renderWithRouter(
+      <OwnerActions
+        post={{ ...basePost, is_owner: false }}
+        user={{ is_superuser: true }}
+        {...baseProps}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the toolbar for a superuser owner with the expected actions", () => {
+    renderWithRouter(
+      <OwnerActions
+        post={basePost}
+        user={{ is_superuser: true }}
+        {...baseProps}
+      />,
+    );
+
+    expect(screen.getByTestId("owner-actions")).toBeInTheDocument();
+    expect(screen.getByText("Auteur")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /modifier/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /supprimer/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /épingler/i })).toBeInTheDocument();
+  });
+
+  it("shows the unpublished-changes hint when hasDraftChanges is true", () => {
+    renderWithRouter(
+      <OwnerActions
+        post={basePost}
+        user={{ is_superuser: true }}
+        {...baseProps}
+        hasDraftChanges
+      />,
+    );
+
+    expect(
+      screen.getByText("Modifications non publiées"),
+    ).toBeInTheDocument();
+  });
+
+  it("uses the responsive sticky utility classes (md+ only)", () => {
+    renderWithRouter(
+      <OwnerActions
+        post={basePost}
+        user={{ is_superuser: true }}
+        {...baseProps}
+      />,
+    );
+
+    const bar = screen.getByTestId("owner-actions");
+    expect(bar.className).toContain("md:sticky");
+    expect(bar.className).toContain("md:top-[var(--header-height)]");
+    expect(bar.className).toContain("md:z-[var(--z-owner-actions)]");
+  });
+});

--- a/frontend/src/components/blog/PostDetail.jsx
+++ b/frontend/src/components/blog/PostDetail.jsx
@@ -13,6 +13,7 @@ import { buildHeadingIndex } from "../../utils/articleToc";
 import ArticleToc from "./ArticleToc";
 import CommentForm from "./CommentForm";
 import CommentSection from "./CommentSection";
+import OwnerActions from "./OwnerActions";
 
 function BlockNoteRenderer({ content, onHeadings }) {
   const blocks = useMemo(() => {
@@ -170,168 +171,6 @@ function LinkedInShareButton({ title }) {
         </svg>
         <span>LinkedIn</span>
       </a>
-    </div>
-  );
-}
-
-function OwnerIcon({ d, filled = false }) {
-  return (
-    <svg
-      width="13"
-      height="13"
-      viewBox="0 0 24 24"
-      fill={filled ? "currentColor" : "none"}
-      stroke="currentColor"
-      strokeWidth="1.6"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d={d} />
-    </svg>
-  );
-}
-
-function OwnerActions({
-  post,
-  publishing,
-  onPublish,
-  pinToggling,
-  onTogglePin,
-  hasVersions,
-  hasDraftChanges,
-}) {
-  const base = {
-    display: "inline-flex",
-    alignItems: "center",
-    gap: 6,
-    fontFamily: '"Inter", system-ui, sans-serif',
-    fontSize: 12,
-    fontWeight: 500,
-    padding: "6px 10px",
-    borderRadius: 3,
-    cursor: "pointer",
-    whiteSpace: "nowrap",
-    textDecoration: "none",
-    transition: "background-color 120ms ease, border-color 120ms ease",
-  };
-  const neutral = {
-    ...base,
-    border: "1px solid rgb(var(--color-editorial-rule))",
-    background: "rgb(var(--color-editorial-card))",
-    color: "rgb(var(--color-editorial-text))",
-  };
-  const primary = {
-    ...base,
-    border: "1px solid rgb(var(--color-editorial-ink))",
-    background: "rgb(var(--color-editorial-ink))",
-    color: "rgb(var(--color-editorial-paper))",
-  };
-  const canPublishDraft = post.status === "draft";
-  const canPublishChanges = post.status === "published" && post.has_draft;
-
-  return (
-    <div
-      style={{
-        display: "flex",
-        gap: 6,
-        flexWrap: "wrap",
-        alignItems: "center",
-        padding: "10px 0",
-        borderTop: "1px solid rgb(var(--color-editorial-rule))",
-        borderBottom: "1px solid rgb(var(--color-editorial-rule))",
-        margin: "28px 0",
-        position: "sticky",
-        top: 68,
-        zIndex: 9,
-        background: "rgb(var(--color-editorial-paper))",
-      }}
-    >
-      <span
-        style={{
-          fontFamily: '"Inter", system-ui, sans-serif',
-          fontSize: 11,
-          color: "rgb(var(--color-editorial-dim))",
-          textTransform: "uppercase",
-          letterSpacing: 1,
-          fontWeight: 500,
-          alignSelf: "center",
-          marginRight: 8,
-        }}
-      >
-        Auteur
-      </span>
-
-      <Link to={`/articles/${post.slug}/modifier`} style={neutral} title="Modifier">
-        <OwnerIcon d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Z" />
-        <span>Modifier</span>
-      </Link>
-
-      {(canPublishDraft || canPublishChanges) && (
-        <button
-          type="button"
-          onClick={onPublish}
-          disabled={publishing}
-          style={{ ...primary, opacity: publishing ? 0.6 : 1 }}
-          title={canPublishChanges ? "Publier les modifications" : "Publier"}
-        >
-          <OwnerIcon d="M12 19.5v-15m0 0-6.75 6.75M12 4.5l6.75 6.75" />
-          <span>
-            {publishing
-              ? "Publication…"
-              : canPublishChanges
-                ? "Publier les modifications"
-                : "Publier"}
-          </span>
-        </button>
-      )}
-
-      {post.status === "published" && (
-        <button
-          type="button"
-          onClick={onTogglePin}
-          disabled={pinToggling}
-          style={{ ...neutral, opacity: pinToggling ? 0.6 : 1 }}
-          title={post.is_pinned ? "Désépingler" : "Épingler à la une"}
-        >
-          <OwnerIcon
-            d="M9 4.5v4.5l-3 3v2.25h12V12l-3-3V4.5m-6 9v6"
-            filled={post.is_pinned}
-          />
-          <span>{post.is_pinned ? "Désépingler" : "Épingler"}</span>
-        </button>
-      )}
-
-      {hasVersions && (
-        <Link to={`/articles/${post.slug}/versions`} style={neutral} title="Versions">
-          <OwnerIcon d="M12 6v6h4.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
-          <span>Versions</span>
-        </Link>
-      )}
-
-      <Link
-        to={`/articles/${post.slug}/supprimer`}
-        style={neutral}
-        title="Supprimer"
-      >
-        <OwnerIcon d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0c.342.052.682.107 1.022.166m-16.5-.165c.34-.059.68-.114 1.022-.165m14.456 0a48.108 48.108 0 0 0-3.478-.397M5.794 5.625a48.11 48.11 0 0 1 3.478-.397M15.272 5.228v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916" />
-        <span>Supprimer</span>
-      </Link>
-
-      <div style={{ flex: 1 }} />
-
-      {hasDraftChanges && (
-        <span
-          style={{
-            fontFamily: '"Inter", system-ui, sans-serif',
-            fontSize: 11,
-            color: "rgb(var(--color-editorial-accent))",
-            alignSelf: "center",
-            fontStyle: "italic",
-          }}
-        >
-          Modifications non publiées
-        </span>
-      )}
     </div>
   );
 }
@@ -520,17 +359,16 @@ export default function PostDetail() {
               </div>
             </div>
 
-            {isOwnerSuperuser && (
-              <OwnerActions
-                post={post}
-                publishing={publishing}
-                onPublish={handlePublish}
-                pinToggling={pinToggling}
-                onTogglePin={handleTogglePin}
-                hasVersions={hasVersions}
-                hasDraftChanges={hasDraftChanges}
-              />
-            )}
+            <OwnerActions
+              post={post}
+              user={user}
+              publishing={publishing}
+              onPublish={handlePublish}
+              pinToggling={pinToggling}
+              onTogglePin={handleTogglePin}
+              hasVersions={hasVersions}
+              hasDraftChanges={hasDraftChanges}
+            />
 
             {isOwnerSuperuser && hasDraftChanges && (
               <Alert color="blue" className="mb-6">
@@ -595,7 +433,7 @@ export default function PostDetail() {
                 paddingTop: 0,
               }}
             >
-              <div className="hidden lg:block lg:sticky lg:top-[68px]">
+              <div className="hidden lg:block lg:sticky lg:top-[var(--header-height)]">
                 <ArticleToc items={headings} />
               </div>
               <div className="border-t border-editorial-rule lg:border-t-0 pt-12 lg:pt-0">

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -19,6 +19,11 @@
     --color-editorial-avatar-bg: 212 231 214;
     --color-editorial-avatar-bg-alt: 227 238 224;
     --color-editorial-avatar-fg: 31 31 31;
+
+    /* Sticky-layout tokens — must stay in sync with Header.jsx height
+       and the z-stack (Header is z-10, OwnerActions sits just below). */
+    --header-height: 68px;
+    --z-owner-actions: 9;
   }
 
   .dark {


### PR DESCRIPTION
## Summary

- Extract `OwnerActions` (and the `OwnerIcon` helper) out of `PostDetail.jsx` into its own component so visibility can be tested in isolation. The component now self-guards on `post.is_owner && user?.is_superuser`, and the parent no longer needs the `isOwnerSuperuser &&` wrapper.
- Replace the magic numbers — `top: 68`, `zIndex: 9` — with two CSS custom properties declared at the `:root` level: `--header-height` (`68px`) and `--z-owner-actions` (`9`). The TOC sticky offset on `lg+` now reads from the same variable, so a future header-height change is one edit.
- **Mobile fix**: the bar is sticky only from the `md` breakpoint (≥ 768px). On smaller viewports it is `position: static` and no longer eats vertical space. Verified in the build CSS: `@media(min-width:768px){.md\:sticky{position:sticky}` is the only `position:sticky` declaration emitted for the toolbar.
- Adds Vitest + Testing Library coverage for the four visibility cases (anonymous / non-superuser owner / superuser non-owner / superuser owner), the unpublished-changes hint, and the responsive sticky utility classes.

Out of scope (carried in #258 / future PRs):
- Manual confirmation that the bar does not overlap the TOC sticky on `lg+` viewports — left as a manual smoke test.

Closes #258

## Test plan

- [x] `cd frontend && npm test` — 19 tests pass (13 articleToc + 6 OwnerActions)
- [x] `cd frontend && npm run build` — production build OK
- [x] Build CSS contains the new variables and the `md:`-scoped `position:sticky`
- [x] Manual: open a published article on a desktop viewport, scroll, confirm the toolbar sticks below the header without overlapping the TOC

🤖 Generated with [Claude Code](https://claude.com/claude-code)